### PR TITLE
update releasing docs & auto-download dependency manager

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,6 @@
 1. Update to the latest SDK versions:
    1. Update the versions in RevenueCatDependencies.xml for Android and iOS
-   1. Update the Android version in the `purchasesunit/build.gradle`
-1. Update the VERSION file and the platformFlavorVersion number in `PurchasesUnityHelper.m`
+1. Update the VERSION file and the platformFlavorVersion number in `PurchasesUnityHelper.m` and `PurchasesWrapper.java`
 1. Update the VERSIONS.md file.
 1. Add an entry to CHANGELOG.md
 1. `git commit -am "Preparing for version x.y.z"`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,4 @@
-1. Update to the latest SDK versions:
-   1. Update the versions in RevenueCatDependencies.xml for Android and iOS
+1. Update to the latest SDK versions in RevenueCatDependencies.xml for Android and iOS
 1. Update the VERSION file and the platformFlavorVersion number in `PurchasesUnityHelper.m` and `PurchasesWrapper.java`
 1. Update the VERSIONS.md file.
 1. Add an entry to CHANGELOG.md
@@ -7,5 +6,4 @@
 1. `git tag x.y.z`
 1. `git push origin master && git push --tags`
 1. Run `./scripts/create-unity-package.sh`
-1. Create a new release in github and upload both packages.
-1. Update docs link to new unity package. Update the version in [here](https://docs.revenuecat.com/docs/unity#1-add-the-purchases-unity-package)
+1. Create a new release in github and upload `Purchases.unitypackage`.

--- a/scripts/create-unity-package.sh
+++ b/scripts/create-unity-package.sh
@@ -38,8 +38,7 @@ if [ -f $PROJECT/external-dependency-manager-*.unitypackage ];
 then
     echo "👌 External dependency manager plugin found. It will be added to the unitypackage."
 else
-    echo "⚠️  External dependency manager plugin not found. Please download the latest version and locate it inside the Subtester folder."
-    exit 1
+    wget https://github.com/googlesamples/unity-jar-resolver/raw/master/external-dependency-manager-latest.unitypackage -P $PROJECT
 fi
 
 if [ -f $PACKAGE ]; 


### PR DESCRIPTION
- updated `RELEASING.md` to reflect changes from 2.3.0
- edited the step that checks for the `external-dependency-manager`, so that instead of crashing if the latest version isn't found, it downloads it automatically. 