### PR TITLE
Updates releasing instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,9 @@
+1. Start a branch release/x.y.z
 1. Update to the latest SDK versions in RevenueCatDependencies.xml for Android and iOS
 1. Update the VERSION file and the platformFlavorVersion number in `PurchasesUnityHelper.m` and `PurchasesWrapper.java`
 1. Update the VERSIONS.md file.
 1. Add an entry to CHANGELOG.md
-1. `git commit -am "Preparing for version x.y.z"`
-1. `git tag x.y.z`
-1. `git push origin master && git push --tags`
-1. Run `./scripts/create-unity-package.sh`
+1. Make a PR, merge when approved
+1. Make a tag and push
+1. CircleCI will run a job `export-package` that will create a `Purchases.unitypackage` for you. Find the package in the artifacts section of the job
 1. Create a new release in github and upload `Purchases.unitypackage`.


### PR DESCRIPTION
https://github.com/RevenueCat/purchases-unity/pull/35 added a job that extracts the `Purchase.unitypackage` required for releasing