### PR TITLE
version 3.0.1

### DIFF
--- a/RevenueCat/Scripts/EntitlementInfo.cs
+++ b/RevenueCat/Scripts/EntitlementInfo.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using RevenueCat.SimpleJSON;
+using static RevenueCat.Utilities;
+
 
 public partial class Purchases
 {
@@ -26,15 +28,15 @@ public partial class Purchases
             IsActive = response["isActive"].AsBool;
             WillRenew = response["willRenew"].AsBool;
             PeriodType = response["periodType"];
-            LatestPurchaseDate = FromUnixTime(response["latestPurchaseDateMillis"].AsLong);
-            OriginalPurchaseDate = FromUnixTime(response["originalPurchaseDateMillis"].AsLong);
+            LatestPurchaseDate = FromUnixTimeInMilliseconds(response["latestPurchaseDateMillis"].AsLong);
+            OriginalPurchaseDate = FromUnixTimeInMilliseconds(response["originalPurchaseDateMillis"].AsLong);
 
             var expirationDateJson = response["expirationDateMillis"];
             var hasExpirationDate = expirationDateJson != null && !expirationDateJson.IsNull &&
                                     expirationDateJson.AsLong != 0L;
             if (hasExpirationDate)
             {
-                ExpirationDate = FromUnixTime(expirationDateJson.AsLong);
+                ExpirationDate = FromUnixTimeInMilliseconds(expirationDateJson.AsLong);
             }
 
             Store = response["store"];
@@ -46,7 +48,7 @@ public partial class Purchases
                                          unsubscribeDetectedJson.AsLong != 0L;
             if (hasUnsubscribeDetected)
             {
-                UnsubscribeDetectedAt = FromUnixTime(unsubscribeDetectedJson.AsLong);
+                UnsubscribeDetectedAt = FromUnixTimeInMilliseconds(unsubscribeDetectedJson.AsLong);
             }
 
             var billingIssueJson = response["billingIssueDetectedAtMillis"];
@@ -54,16 +56,9 @@ public partial class Purchases
                                   billingIssueJson.AsLong != 0L;
             if (hasBillingIssue)
             {
-                BillingIssueDetectedAt = FromUnixTime(billingIssueJson.AsLong);
+                BillingIssueDetectedAt = FromUnixTimeInMilliseconds(billingIssueJson.AsLong);
             }
         }
-
-        private static DateTime FromUnixTime(long unixTime)
-        {
-            return Epoch.AddSeconds(unixTime);
-        }
-
-        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         public override string ToString()
         {

--- a/RevenueCat/Scripts/PurchaserInfo.cs
+++ b/RevenueCat/Scripts/PurchaserInfo.cs
@@ -47,13 +47,13 @@ public partial class Purchases
                 AllPurchasedProductIdentifiers.Add(productIdentifier);
             }
 
-            FirstSeen = FromUnixTime(response["firstSeenMillis"].AsLong);
+            FirstSeen = FromUnixTimeInMilliseconds(response["firstSeenMillis"].AsLong);
             OriginalAppUserId = response["originalAppUserId"];
-            RequestDate = FromUnixTime(response["requestDateMillis"].AsLong);
+            RequestDate = FromUnixTimeInMilliseconds(response["requestDateMillis"].AsLong);
             OriginalPurchaseDate =
-                FromOptionalUnixTime(response["originalPurchaseDateMillis"].AsLong);
+                FromOptionalUnixTimeInMilliseconds(response["originalPurchaseDateMillis"].AsLong);
             LatestExpirationDate =
-                FromOptionalUnixTime(response["latestExpirationDateMillis"].AsLong);
+                FromOptionalUnixTimeInMilliseconds(response["latestExpirationDateMillis"].AsLong);
             ManagementURL = response["managementURL"];
             AllExpirationDates = new Dictionary<string, DateTime?>();
             foreach (var keyValue in response["allExpirationDatesMillis"])
@@ -62,7 +62,7 @@ public partial class Purchases
                 var expirationDateJSON = keyValue.Value;
                 if (expirationDateJSON != null && !expirationDateJSON.IsNull && expirationDateJSON.AsLong != 0L)
                 {
-                    AllExpirationDates.Add(productID, FromUnixTime(expirationDateJSON.AsLong));
+                    AllExpirationDates.Add(productID, FromUnixTimeInMilliseconds(expirationDateJSON.AsLong));
                 }
                 else
                 {
@@ -73,7 +73,7 @@ public partial class Purchases
             AllPurchaseDates = new Dictionary<string, DateTime>();
             foreach (var keyValue in response["allPurchaseDatesMillis"])
             {
-                AllPurchaseDates.Add(keyValue.Key, FromUnixTime(keyValue.Value.AsLong));
+                AllPurchaseDates.Add(keyValue.Key, FromUnixTimeInMilliseconds(keyValue.Value.AsLong));
             }
 
             OriginalApplicationVersion = response["originalApplicationVersion"];

--- a/RevenueCat/Scripts/Transaction.cs
+++ b/RevenueCat/Scripts/Transaction.cs
@@ -1,5 +1,7 @@
 using System;
 using RevenueCat.SimpleJSON;
+using static RevenueCat.Utilities;
+
 
 public partial class Purchases
 {    
@@ -28,7 +30,7 @@ public partial class Purchases
         {
             RevenueCatId = response["revenueCatId"];
             ProductId = response["productId"];
-            PurchaseDate = RevenueCat.Utilities.FromUnixTime(response["purchaseDateMillis"].AsLong);
+            PurchaseDate = FromUnixTimeInMilliseconds(response["purchaseDateMillis"].AsLong);
         } 
         
         public override string ToString()

--- a/RevenueCat/Scripts/Utilities.cs
+++ b/RevenueCat/Scripts/Utilities.cs
@@ -3,16 +3,16 @@ using System;
 namespace RevenueCat
 {
     internal static class Utilities {
-        internal static DateTime FromUnixTime(long unixTime)
+        internal static DateTime FromUnixTimeInMilliseconds(long unixTimeInMilliseconds)
         {
-            return Epoch.AddSeconds(unixTime);
+            return Epoch.AddSeconds(unixTimeInMilliseconds / 1000.0);
         }
     
-        internal static DateTime? FromOptionalUnixTime(long unixTime)
+        internal static DateTime? FromOptionalUnixTimeInMilliseconds(long unixTimeInMilliseconds)
         {
             DateTime? value = null;
-            if (unixTime != 0L) { 
-                value = FromUnixTime(unixTime);
+            if (unixTimeInMilliseconds != 0L) { 
+                value = FromUnixTimeInMilliseconds(unixTimeInMilliseconds);
             }
             return value;
         }


### PR DESCRIPTION
- Fixed a crash in iOS when parsing dates in milliseconds, as well as a bug in Android that caused dates that were reported as `milliseconds` to actually have values in seconds. 
https://github.com/RevenueCat/purchases-unity/pull/39
- Bumped `purchases-hybrid-common` to 1.5.1 [Changelog here](https://github.com/RevenueCat/purchases-hybrid-common/releases/1.5.0)
