### PR TITLE
Specify Android purchases-hybrid-common version

### DIFF
--- a/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
+++ b/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:1.6.1" />
+        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[1.6.1]" />
     </androidPackages>
     <iosPods>
         <iosPod name="PurchasesHybridCommon" version="1.6.1" minTargetSdk="9.0"/>


### PR DESCRIPTION
Looks like for some people, EDM4U downloads alpha versions. This should make sure only a specific is downloaded

Issue reported in https://spectrum.chat/revenuecat/general/unity-sdk-issue-with-purchaseswrapper-java~f2fa488f-1890-4f0f-9306-489bf0a4e700