### PR TITLE
Fix: missing meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .DS_Store
-*.meta
-!SubTester/**/*.meta
 .idea/
 org.eclipse.buildship.core.prefs
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.meta
+!SubTester/**/*.meta
 .idea/
 org.eclipse.buildship.core.prefs
 .project

--- a/RevenueCat/Example.meta
+++ b/RevenueCat/Example.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5996bb38bd034473ab3f57520ef12580
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Example/PurchasesListener.cs.meta
+++ b/RevenueCat/Example/PurchasesListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4d983d93d67c4367bf31ba35790ced8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins.meta
+++ b/RevenueCat/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88ad781b7b3144d7b918258eeb6d7e8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/Android.meta
+++ b/RevenueCat/Plugins/Android.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 433cd96e7e7854b96b2645981af4e0f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java.meta
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 2d678c4667ee44abca81e2f14efaa4a2
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/Editor.meta
+++ b/RevenueCat/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7dfbb0c271244d67b758e7eaeb606b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml.meta
+++ b/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2b04e64e43c0644a18893efa44a28d41
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/iOS.meta
+++ b/RevenueCat/Plugins/iOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4aaa156ec5da24f2384a3fabed599525
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/iOS/Dummy.swift.meta
+++ b/RevenueCat/Plugins/iOS/Dummy.swift.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: 0c5e0a408ca1147a8a9b27285d3bec5b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m.meta
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: 3a6205651e4e148c582ef8da4cfbed73
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts.meta
+++ b/RevenueCat/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d2cb6068f9254318ba2db26f793c001
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/AttributionNetwork.cs.meta
+++ b/RevenueCat/Scripts/AttributionNetwork.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7046838bf9bc4eaa98458da1c8e3f60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/EntitlementInfo.cs.meta
+++ b/RevenueCat/Scripts/EntitlementInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a73077079902f4235a3193870d3d27d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/EntitlementInfos.cs.meta
+++ b/RevenueCat/Scripts/EntitlementInfos.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cdb299f205e449169b5412e5e2aa3c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Error.cs.meta
+++ b/RevenueCat/Scripts/Error.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f51ce4b41d9be4b64a9d1ddf44a339ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/IntroEligibility.cs.meta
+++ b/RevenueCat/Scripts/IntroEligibility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac0753fb5fb0f44ab9250501c1e61d29
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/IntroEligibilityStatus.cs.meta
+++ b/RevenueCat/Scripts/IntroEligibilityStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64cdb7aa027e348a2a5a68fee63383a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Offering.cs.meta
+++ b/RevenueCat/Scripts/Offering.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 982ceda29abdf46c8a249ecefac7236a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Offerings.cs.meta
+++ b/RevenueCat/Scripts/Offerings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 437241e31464343059b5e06e24298d21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Package.cs.meta
+++ b/RevenueCat/Scripts/Package.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 576b27c978fd5425791ce9403e66c507
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Product.cs.meta
+++ b/RevenueCat/Scripts/Product.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f670fd215a5404a9e9f1f99220da899c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/ProrationMode.cs.meta
+++ b/RevenueCat/Scripts/ProrationMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f040cb79e9424e2398346f925a9fdcf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/PurchaserInfo.cs.meta
+++ b/RevenueCat/Scripts/PurchaserInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c2cb443cf76b4361b46bf3a3353622a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Purchases.cs.meta
+++ b/RevenueCat/Scripts/Purchases.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98e401cc5a2ed4a7ba02f2e6ef35c6f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/PurchasesWrapper.cs.meta
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11f0910f19d434a9d98b040927b8c897
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs.meta
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e9d22f5321c846ef983f7d2f5247d8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs.meta
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d811f00fc4b248788a9f09ba198c7ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs.meta
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4df5bc215b9343aa94a90df70414f1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/SimpleJSON.cs.meta
+++ b/RevenueCat/Scripts/SimpleJSON.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7aae9850938064db299b2f103344b9fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Transaction.cs.meta
+++ b/RevenueCat/Scripts/Transaction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f202d54df854a4a81878396e98afcb41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/UpdatedPurchaserInfoListener.cs.meta
+++ b/RevenueCat/Scripts/UpdatedPurchaserInfoListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7be2a28dc29c74f729d853e3feca52b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Utilities.cs.meta
+++ b/RevenueCat/Scripts/Utilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e724c49245cc74f20b63ed54bc2d9a8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager.meta
+++ b/Subtester/Assets/ExternalDependencyManager.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b79b031d2247843c08f21033da3c1996
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b1a7905e3bf84f238958efd88cd7a13
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/CHANGELOG.md.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32b0d9741e46b4010a5dc3b7b8eae05a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.IOSResolver_v1.2.156.dll.mdb.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.IOSResolver_v1.2.156.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 53377c7597ea040a2b2a3a378e1c043b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.IOSResolver_v1.2.156.dll.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.IOSResolver_v1.2.156.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: de3a63e8f0fab432689fe0aebba03f94
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.JarResolver_v1.2.156.dll.mdb.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.JarResolver_v1.2.156.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15f555a1e5ad7428c8eaa196527eeb51
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.JarResolver_v1.2.156.dll.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.JarResolver_v1.2.156.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 5013b52dcb8ac488aa46bea6e300b92a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.PackageManagerResolver_v1.2.156.dll.mdb.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.PackageManagerResolver_v1.2.156.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1404aae4b14e6423bb512518b8c71390
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.PackageManagerResolver_v1.2.156.dll.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.PackageManagerResolver_v1.2.156.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: c436307fe0c9d4809b6d2e272aa9cf94
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandler.dll.mdb.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandler.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de2750734217a45f8a6ea4499332589a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandler.dll.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandler.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 20a01f27fb98c446ba0d9f29df684481
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandlerImpl_v1.2.156.dll.mdb.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandlerImpl_v1.2.156.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12dea5632717549fc9f53ea2e91434f0
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandlerImpl_v1.2.156.dll.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/Google.VersionHandlerImpl_v1.2.156.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 7efb28d9d63e34493b1d9290a23f8ee3
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/GoogleRegistries.xml.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/GoogleRegistries.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 40ffe4a33fec84df5b118b00f947fa97
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/LICENSE.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 07d7bd61bb2764b8f9f6e0869fdfe7c3
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/README.md.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54b040018f66e417ba7cf5f12464215a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/ExternalDependencyManager/Editor/external-dependency-manager_version-1.2.156_manifest.txt.meta
+++ b/Subtester/Assets/ExternalDependencyManager/Editor/external-dependency-manager_version-1.2.156_manifest.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7eb683edb1da34f50bb9478b4a74adb1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/PlayServicesResolver.meta
+++ b/Subtester/Assets/PlayServicesResolver.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e14b5d9df70e54682ba26cfcd2f38acb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/PlayServicesResolver/Editor.meta
+++ b/Subtester/Assets/PlayServicesResolver/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97c6f1182988c45a3a0183368cea17fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/PlayServicesResolver/Editor/play-services-resolver_v1.2.137.0.txt.meta
+++ b/Subtester/Assets/PlayServicesResolver/Editor/play-services-resolver_v1.2.137.0.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1ea625bca6447439d91241bce681c4ec
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/Plugins.meta
+++ b/Subtester/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2931eeb79d9d54e2d88e5cb449ed2b42
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/RevenueCat.meta
+++ b/Subtester/Assets/RevenueCat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a4a5d8d56a764a9d96a4c99e399d6a1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/Scenes.meta
+++ b/Subtester/Assets/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df533e3901515427e8be822a4ffdc3cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/Scenes/BuyButton.prefab.meta
+++ b/Subtester/Assets/Scenes/BuyButton.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 08be051e1286142ac9bb1c2a81c63bc3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/Scenes/Main.unity
+++ b/Subtester/Assets/Scenes/Main.unity
@@ -234,7 +234,7 @@ MonoBehaviour:
   revenueCatAPIKey: 
   appUserID: 
   productIdentifiers: []
-  listener: {fileID: 0}
+  listener: {fileID: 559298755}
   observerMode: 0
   userDefaultsSuiteName: 
   proxyURL: 

--- a/Subtester/Assets/Scenes/Main.unity
+++ b/Subtester/Assets/Scenes/Main.unity
@@ -173,6 +173,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -227,13 +228,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 559298752}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1066017fd38404493828b48915eb4d49, type: 3}
+  m_Script: {fileID: 11500000, guid: 98e401cc5a2ed4a7ba02f2e6ef35c6f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  revenueCatAPIKey: VtDdmbdWBySmqJeeQUTyrNxETUVkhuaJ
+  revenueCatAPIKey: 
   appUserID: 
   productIdentifiers: []
-  listener: {fileID: 559298755}
+  listener: {fileID: 0}
   observerMode: 0
   userDefaultsSuiteName: 
   proxyURL: 
@@ -260,11 +261,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 559298752}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea6a3555b4d8f4385aaa5bbc4ca6edc3, type: 3}
+  m_Script: {fileID: 11500000, guid: d4d983d93d67c4367bf31ba35790ced8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   parentPanel: {fileID: 1575378375}
-  buttonPrefab: {fileID: 1696602566380582, guid: cacc06bcb22a64073bbe88de11c1149f,
+  buttonPrefab: {fileID: 1696602566380582, guid: 08be051e1286142ac9bb1c2a81c63bc3,
     type: 3}
   purchaserInfoLabel: {fileID: 53425791}
 --- !u!1 &1090981152
@@ -385,6 +386,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.392}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Subtester/Assets/Scenes/Main.unity.meta
+++ b/Subtester/Assets/Scenes/Main.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a96ba31ae29a048edadf6ae1941bb42a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scripts/create-unity-package.sh
+++ b/scripts/create-unity-package.sh
@@ -19,7 +19,7 @@ fi
 
 if [ -z "$UNITY_BIN" ]; then
     echo "😞 Unity not passed as parameter!"
-    echo "Pass the location of Unity. Something like ./scripts/create-unity-package.sh /Applications/Unity/Hub/Editor/2019.3.10f1/Unity.app/Contents/MacOS/Unity"
+    echo "Pass the location of Unity. Something like ./scripts/create-unity-package.sh -u /Applications/Unity/Hub/Editor/2019.3.10f1/Unity.app/Contents/MacOS/Unity"
     exit 1
 fi
 


### PR DESCRIPTION
When checking out our repo and using the `SubTester` sample app, the objects being referenced in the Editor wouldn't work correctly and would have to be re-wired every time. 

This is because we were missing the `.meta` files in the repo, which contain the guuids that Unity uses to reference objects. 

This PR adds them so that they can be correctly referenced now. 