### PR TITLE
[github] update issue templates with emojis, same feature request url

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Filling a bug report
 title: ""
 labels: bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,24 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🚥 RevenueCat system status
+    url: https://status.revenuecat.com
+    about: Check RevenueCat's API status
+  - name: 🙋 Our online community
+    url: https://community.revenuecat.com
+    about: Please ask and answer questions at https://community.revenuecat.com
+  - name: 🧾 Account or billing support
+    url: https://app.revenuecat.com/settings/support
+    about: Get help from our support team
+  - name: ✨ Feature request
+    url: https://app.revenuecat.com/settings/support
+    about: Please use the Contact Us form instead of opening an issue. This is best channel that allows us to keep track of feature requests.
+  - name: ❓ Offerings, products, or available packages are empty
+    url: https://community.revenuecat.com/search?q=why_are_offerings_empty&content_type[0]=discussion
+    about: Why are my products, offerings, or available packages empty?
+  - name: ❓ Invalid Play Store credentials errors
+    url: https://community.revenuecat.com/search?q=invalid_play_store_credentials&content_type%5B0%5D=discussion
+    about: How to solve Play Store credentials errors
+  - name: ❓ Unable to connect to the App Store (STORE_PROBLEM) errors
+    url: https://community.revenuecat.com/search?q=store%20problem&content_type%5B0%5D=discussion
+    about: Why I get STORE_PROBLEM errors
+    

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: ✨ Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-Please use https://support.revenuecat.com/hc/en-us/articles/360046422033-Feature-Requests instead of opening an issue. That is the best channel that allows us to keep track of feature requests.
+Please use https://app.revenuecat.com/settings/support instead of opening an issue. That is the best channel that allows us to keep track of feature requests.


### PR DESCRIPTION
Similar to https://github.com/RevenueCat/purchases-ios/pull/1088

## Motivation
Make issue templates fun and easy to scan with emojis that can help the user find the right item they are looking for 

## Description
- Prefixed issue templates with meaningful emojis
- Updated all feature requests links to go to https://app.revenuecat.com/settings/support (after getting confirmation from support slack channel)
- Added `config.yml` to show contact links that other repos are using