### PR TITLE
add new fields for separate API keys

### DIFF
--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 using System;
 using System.Collections.Generic;
 using RevenueCat.SimpleJSON;
@@ -41,9 +42,21 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     public delegate void GetPaymentDiscountFunc(PaymentDiscount paymentDiscount, Error error);
 
-    [Tooltip("Your RevenueCat API Key. Get from https://app.revenuecat.com/")]
+    [FormerlySerializedAs("revenueCatAPIKey")]
+    [ObsoleteAttribute("This property is obsolete. Use revenueCatAPIKeyIOS and revenueCatAPIKeyAndroid instead.", false)]
+    [Tooltip("(DEPRECATED) RevenueCat API Key. Get from https://app.revenuecat.com/. " +
+             "This property is obsolete. " +
+             "Use revenueCatAPIKeyIOS and revenueCatAPIKeyAndroid instead.")]
     // ReSharper disable once InconsistentNaming
-    public string revenueCatAPIKey;
+    public string deprecatedLegacyRevenueCatAPIKey;
+
+    [Tooltip("RevenueCat API Key specifically for iOS. Get from https://app.revenuecat.com/")]
+    // ReSharper disable once InconsistentNaming
+    public string revenueCatAPIKeyIOS;
+
+    [Tooltip("RevenueCat API Key specifically for Android. Get from https://app.revenuecat.com/")]
+    // ReSharper disable once InconsistentNaming
+    public string revenueCatAPIKeyAndroid;
 
     [Tooltip(
         "App user id. Pass in your own ID if your app has accounts. If blank, RevenueCat will generate a user ID for you.")]
@@ -88,7 +101,16 @@ public partial class Purchases : MonoBehaviour
     // Call this if you want to reset with a new user id
     private void Setup(string newUserId)
     {
-        _wrapper.Setup(gameObject.name, revenueCatAPIKey, newUserId, observerMode, userDefaultsSuiteName);
+        var apiKey = deprecatedLegacyRevenueCatAPIKey;
+        if (String.IsNullOrEmpty(apiKey))
+        {
+            if (Application.platform == RuntimePlatform.IPhonePlayer)
+                apiKey = revenueCatAPIKeyIOS;
+            else if (Application.platform == RuntimePlatform.Android)
+                apiKey = revenueCatAPIKeyAndroid;
+        }
+        
+        _wrapper.Setup(gameObject.name, apiKey, newUserId, observerMode, userDefaultsSuiteName);
     }
 
     private GetProductsFunc ProductsCallback { get; set; }

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -43,10 +43,10 @@ public partial class Purchases : MonoBehaviour
     public delegate void GetPaymentDiscountFunc(PaymentDiscount paymentDiscount, Error error);
 
     [FormerlySerializedAs("revenueCatAPIKey")]
-    [ObsoleteAttribute("This property is obsolete. Use revenueCatAPIKeyApple and revenueCatAPIKeyAndroid instead.", false)]
+    [ObsoleteAttribute("This property is obsolete. Use revenueCatAPIKeyApple and revenueCatAPIKeyGoogle instead.", false)]
     [Tooltip("(DEPRECATED) RevenueCat API Key. Get from https://app.revenuecat.com/. " +
              "This property is obsolete. " +
-             "Use revenueCatAPIKeyApple and revenueCatAPIKeyAndroid instead.")]
+             "Use revenueCatAPIKeyApple and revenueCatAPIKeyGoogle instead.")]
     // ReSharper disable once InconsistentNaming
     public string deprecatedLegacyRevenueCatAPIKey;
 
@@ -56,7 +56,7 @@ public partial class Purchases : MonoBehaviour
 
     [Tooltip("RevenueCat API Key specifically for Android. Get from https://app.revenuecat.com/")]
     // ReSharper disable once InconsistentNaming
-    public string revenueCatAPIKeyAndroid;
+    public string revenueCatAPIKeyGoogle;
 
     [Tooltip(
         "App user id. Pass in your own ID if your app has accounts. If blank, RevenueCat will generate a user ID for you.")]
@@ -106,7 +106,7 @@ public partial class Purchases : MonoBehaviour
             || Application.platform == RuntimePlatform.OSXPlayer)
             apiKey = revenueCatAPIKeyApple;
         else if (Application.platform == RuntimePlatform.Android)
-            apiKey = revenueCatAPIKeyAndroid;
+            apiKey = revenueCatAPIKeyGoogle;
 
         if (String.IsNullOrEmpty(apiKey))
             apiKey = deprecatedLegacyRevenueCatAPIKey;

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -101,15 +101,16 @@ public partial class Purchases : MonoBehaviour
     // Call this if you want to reset with a new user id
     private void Setup(string newUserId)
     {
-        var apiKey = deprecatedLegacyRevenueCatAPIKey;
-        if (String.IsNullOrEmpty(apiKey))
-        {
-            if (Application.platform == RuntimePlatform.IPhonePlayer)
-                apiKey = revenueCatAPIKeyIOS;
-            else if (Application.platform == RuntimePlatform.Android)
-                apiKey = revenueCatAPIKeyAndroid;
-        }
+        var apiKey = "";
         
+        if (Application.platform == RuntimePlatform.IPhonePlayer)
+            apiKey = revenueCatAPIKeyIOS;
+        else if (Application.platform == RuntimePlatform.Android)
+            apiKey = revenueCatAPIKeyAndroid;
+
+        if (String.IsNullOrEmpty(apiKey))
+            apiKey = deprecatedLegacyRevenueCatAPIKey;
+
         _wrapper.Setup(gameObject.name, apiKey, newUserId, observerMode, userDefaultsSuiteName);
     }
 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -43,16 +43,16 @@ public partial class Purchases : MonoBehaviour
     public delegate void GetPaymentDiscountFunc(PaymentDiscount paymentDiscount, Error error);
 
     [FormerlySerializedAs("revenueCatAPIKey")]
-    [ObsoleteAttribute("This property is obsolete. Use revenueCatAPIKeyIOS and revenueCatAPIKeyAndroid instead.", false)]
+    [ObsoleteAttribute("This property is obsolete. Use revenueCatAPIKeyApple and revenueCatAPIKeyAndroid instead.", false)]
     [Tooltip("(DEPRECATED) RevenueCat API Key. Get from https://app.revenuecat.com/. " +
              "This property is obsolete. " +
-             "Use revenueCatAPIKeyIOS and revenueCatAPIKeyAndroid instead.")]
+             "Use revenueCatAPIKeyApple and revenueCatAPIKeyAndroid instead.")]
     // ReSharper disable once InconsistentNaming
     public string deprecatedLegacyRevenueCatAPIKey;
 
-    [Tooltip("RevenueCat API Key specifically for iOS. Get from https://app.revenuecat.com/")]
+    [Tooltip("RevenueCat API Key specifically for Apple platforms. Get from https://app.revenuecat.com/")]
     // ReSharper disable once InconsistentNaming
-    public string revenueCatAPIKeyIOS;
+    public string revenueCatAPIKeyApple;
 
     [Tooltip("RevenueCat API Key specifically for Android. Get from https://app.revenuecat.com/")]
     // ReSharper disable once InconsistentNaming
@@ -103,8 +103,9 @@ public partial class Purchases : MonoBehaviour
     {
         var apiKey = "";
         
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-            apiKey = revenueCatAPIKeyIOS;
+        if (Application.platform == RuntimePlatform.IPhonePlayer
+            || Application.platform == RuntimePlatform.OSXPlayer)
+            apiKey = revenueCatAPIKeyApple;
         else if (Application.platform == RuntimePlatform.Android)
             apiKey = revenueCatAPIKeyAndroid;
 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -98,7 +98,6 @@ public partial class Purchases : MonoBehaviour
         GetProducts(productIdentifiers, null);
     }
 
-    // Call this if you want to reset with a new user id
     private void Setup(string newUserId)
     {
         var apiKey = "";


### PR DESCRIPTION
Opening up as a draft to get feedback. 

This adds separate fields for API keys. 
It doesn't remove the old field, but instead marks it as deprecated. 

Notes: 
- the deprecated field will show up as a build warning, but no warnings show up in the editor. So I added the word `deprecated` to its name. 
- I'm automatically switching which field to use based on the current platform. We don't do this for other platforms, but usually you'd get a chance to select which API key you're using in code, and in Unity this is done via editor.
- I renamed the old field but also added a `FormerlySerializedAs` attribute, which will ensure existing projects won't break, since references to the old field will continue to work. 

<img width="297" alt="Screen Shot 2021-12-29 at 5 54 20 PM" src="https://user-images.githubusercontent.com/3922667/147702936-8dd9350f-a79b-4c3d-a1af-65bfb7aa4719.png">


[sc-12104]