### PR TITLE
added post install script to prevent upload error

### DIFF
--- a/RevenueCat/Editor.meta
+++ b/RevenueCat/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f85917eddcec94bb9b4d2a4591b196b9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Editor/RevenueCatPostInstall.cs
+++ b/RevenueCat/Editor/RevenueCatPostInstall.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+ 
+namespace Editor
+{
+    public static class XcodeSwiftVersionPostProcess
+    {
+        [PostProcessBuild(999)]
+        public static void OnPostProcessBuild(BuildTarget buildTarget, string path)
+        {
+            if (buildTarget == BuildTarget.iOS)
+            {
+                ModifyFrameworks(path);
+            }
+        }
+ 
+        private static void ModifyFrameworks(string path)
+        {
+            string projPath = PBXProject.GetPBXProjectPath(path);
+           
+            var project = new PBXProject();
+            project.ReadFromFile(projPath);
+ 
+            string mainTargetGuid = project.GetUnityMainTargetGuid();
+           
+            foreach (var targetGuid in new[] { mainTargetGuid, project.GetUnityFrameworkTargetGuid() })
+            {
+                project.SetBuildProperty(targetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "NO");
+            }
+           
+            project.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
+ 
+            project.WriteToFile(projPath);
+        }
+    }
+}

--- a/RevenueCat/Editor/RevenueCatPostInstall.cs.meta
+++ b/RevenueCat/Editor/RevenueCatPostInstall.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ab0a33bedd9644c583f0d5e05c3bcc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a post install script to fix an error in validation when uploading to App Store Connect. 

The script sets `ALWAYS_EMBED_SWIFT_LIBRARIES` to `NO`. 

It gets run automatically if it's added to the `Editor` folder, and when importing the `.unitypackage` file, it'll be one of the suggested files. 

We also need to update instructions to tell folks to make sure that that file gets imported (we already have similar instructions to make sure that the dependency manager gets imported). 

Fixes #82 