### PR TITLE
Auto add storekit

### DIFF
--- a/RevenueCat/Editor/RevenueCatPostInstall.cs
+++ b/RevenueCat/Editor/RevenueCatPostInstall.cs
@@ -8,6 +8,7 @@ namespace Editor
 {
     public static class XcodeSwiftVersionPostProcess
     {
+        // set callbackOrder to 999 to ensure this runs as the last post process step
         [PostProcessBuild(999)]
         public static void OnPostProcessBuild(BuildTarget buildTarget, string path)
         {

--- a/RevenueCat/Editor/RevenueCatPostInstall.cs
+++ b/RevenueCat/Editor/RevenueCatPostInstall.cs
@@ -14,15 +14,14 @@ namespace Editor
             if (buildTarget == BuildTarget.iOS)
             {
                 ModifyFrameworks(path);
+                AddStoreKitFramework(path);
+                SaveProject(path);
             }
         }
  
         private static void ModifyFrameworks(string path)
         {
-            string projPath = PBXProject.GetPBXProjectPath(path);
-           
-            var project = new PBXProject();
-            project.ReadFromFile(projPath);
+            var project = GetProject(path);
  
             string mainTargetGuid = project.GetUnityMainTargetGuid();
            
@@ -32,8 +31,29 @@ namespace Editor
             }
            
             project.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
- 
+        }
+
+        private static void AddStoreKitFramework(string path)
+        {
+            var project = GetProject(path);
+            string mainTargetGUID = PBXProject.GetUnityMainTargetGuid();
+            project.AddFrameworkToProject(mainTargetGUID, "StoreKit", false);
+        }
+
+        private static PBXProject GetProject(string path)
+        {
+            string projPath = PBXProject.GetPBXProjectPath(path);
+            var project = new PBXProject();
+            project.ReadFromFile(projPath);
+            return project
+        }
+
+        private static void SaveProject(string path)
+        {
+            string projPath = PBXProject.GetPBXProjectPath(path);
+            var project = GetProject(path);
             project.WriteToFile(projPath);
         }
+        
     }
 }

--- a/RevenueCat/Editor/RevenueCatPostInstall.cs
+++ b/RevenueCat/Editor/RevenueCatPostInstall.cs
@@ -15,14 +15,15 @@ namespace Editor
             {
                 ModifyFrameworks(path);
                 AddStoreKitFramework(path);
-                SaveProject(path);
             }
         }
  
         private static void ModifyFrameworks(string path)
         {
-            var project = GetProject(path);
- 
+            string projPath = PBXProject.GetPBXProjectPath(path);
+            var project = new PBXProject();
+            project.ReadFromFile(projPath);
+
             string mainTargetGuid = project.GetUnityMainTargetGuid();
            
             foreach (var targetGuid in new[] { mainTargetGuid, project.GetUnityFrameworkTargetGuid() })
@@ -31,27 +32,19 @@ namespace Editor
             }
            
             project.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
+
+            project.WriteToFile(projPath);
         }
 
         private static void AddStoreKitFramework(string path)
         {
-            var project = GetProject(path);
-            string mainTargetGUID = PBXProject.GetUnityMainTargetGuid();
-            project.AddFrameworkToProject(mainTargetGUID, "StoreKit", false);
-        }
-
-        private static PBXProject GetProject(string path)
-        {
             string projPath = PBXProject.GetPBXProjectPath(path);
             var project = new PBXProject();
             project.ReadFromFile(projPath);
-            return project
-        }
-
-        private static void SaveProject(string path)
-        {
-            string projPath = PBXProject.GetPBXProjectPath(path);
-            var project = GetProject(path);
+            
+            string mainTargetGUID = project.GetUnityMainTargetGuid();
+            project.AddFrameworkToProject(mainTargetGUID, "StoreKit.framework", false);
+            
             project.WriteToFile(projPath);
         }
         


### PR DESCRIPTION
Automatically adds `StoreKit` framework to the main target. 

This slightly simplifies the installation process, since it's one less thing you need to do. 

Fixes https://github.com/RevenueCat/purchases-unity/issues/72.

| Before | After |
| :-: | :-: |
| <img width="725" alt="Screen Shot 2022-02-03 at 6 02 02 PM" src="https://user-images.githubusercontent.com/3922667/152431662-a753491f-8ee3-487c-b770-2714fd9cb4e1.png"> | <img width="674" alt="Screen Shot 2022-02-03 at 6 27 20 PM" src="https://user-images.githubusercontent.com/3922667/152431743-e66615d2-926a-40be-a5e8-f4143c38d3b2.png">  |
