### PR TITLE
Detect Android emulator for Android setup

### DIFF
--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -115,13 +115,12 @@ public partial class Purchases : MonoBehaviour
         _wrapper.Setup(gameObject.name, apiKey, newUserId, observerMode, userDefaultsSuiteName);
     }
 
-    public bool IsAndroidEmulator()
+    private bool IsAndroidEmulator()
     {
         try
         {
             // From https://stackoverflow.com/questions/51880866/detect-if-game-running-in-android-emulator
-            AndroidJavaClass osBuild;
-            osBuild = new AndroidJavaClass("android.os.Build");
+            AndroidJavaClass osBuild = new AndroidJavaClass("android.os.Build");
             string fingerPrint = osBuild.GetStatic<string>("FINGERPRINT");
             return fingerPrint.Contains("generic");
         }

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -101,17 +101,35 @@ public partial class Purchases : MonoBehaviour
     private void Setup(string newUserId)
     {
         var apiKey = "";
-        
+
         if (Application.platform == RuntimePlatform.IPhonePlayer
             || Application.platform == RuntimePlatform.OSXPlayer)
             apiKey = revenueCatAPIKeyApple;
-        else if (Application.platform == RuntimePlatform.Android)
+        else if (Application.platform == RuntimePlatform.Android
+            || IsAndroidEmulator())
             apiKey = revenueCatAPIKeyGoogle;
 
         if (String.IsNullOrEmpty(apiKey))
             apiKey = deprecatedLegacyRevenueCatAPIKey;
 
         _wrapper.Setup(gameObject.name, apiKey, newUserId, observerMode, userDefaultsSuiteName);
+    }
+
+    public bool IsAndroidEmulator()
+    {
+        try
+        {
+            // From https://stackoverflow.com/questions/51880866/detect-if-game-running-in-android-emulator
+            AndroidJavaClass osBuild;
+            osBuild = new AndroidJavaClass("android.os.Build");
+            string fingerPrint = osBuild.GetStatic<string>("FINGERPRINT");
+            return fingerPrint.Contains("generic");
+        }
+        catch
+        {
+            // Throws error when running on non-Android platforms
+            return false;
+        }
     }
 
     private GetProductsFunc ProductsCallback { get; set; }


### PR DESCRIPTION
## Motivation
Fixes #89
Some Android emulators were not being detected by the `RuntimePlatform.Android` check

## Description
- Some emulators (not all) are not detected by `Application.platform == RuntimePlatform.Android`
- Adds `IsAndroidEmulator()` function
  - Attempts to initialize an `android.os.Build` class to extract the `FINGERPRINT`
  - If `FINGERPRINT` is `generic` then it should be an Android emulator
  - Wrapped in try/catch because creating `AndroidJavaClass` will fail on iOS

⁉️ Additional thought... We could just get rid of the `FINGERPRINT` and rely on `AndroidJavaClass` because we don't care if its an emulator or not. We only care about it its an Android device 🤷‍♂️ 