### PR TITLE
Remove namespace Editor from post install to preven collision

### DIFF
--- a/RevenueCat/Editor/RevenueCatPostInstall.cs
+++ b/RevenueCat/Editor/RevenueCatPostInstall.cs
@@ -7,52 +7,49 @@ using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
  
-namespace Editor
+public static class XcodeSwiftVersionPostProcess
 {
-    public static class XcodeSwiftVersionPostProcess
+    // set callbackOrder to 999 to ensure this runs as the last post process step
+    [PostProcessBuild(999)]
+    public static void OnPostProcessBuild(BuildTarget buildTarget, string path)
     {
-        // set callbackOrder to 999 to ensure this runs as the last post process step
-        [PostProcessBuild(999)]
-        public static void OnPostProcessBuild(BuildTarget buildTarget, string path)
+        if (buildTarget == BuildTarget.iOS)
         {
-            if (buildTarget == BuildTarget.iOS)
-            {
-                Debug.Log("Installing for iOS. Setting ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO and adding StoreKit");
-                ModifyFrameworks(path);
-                AddStoreKitFramework(path);
-            }
+            Debug.Log("Installing for iOS. Setting ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO and adding StoreKit");
+            ModifyFrameworks(path);
+            AddStoreKitFramework(path);
         }
- 
-        private static void ModifyFrameworks(string path)
+    }
+
+    private static void ModifyFrameworks(string path)
+    {
+        string projPath = PBXProject.GetPBXProjectPath(path);
+        var project = new PBXProject();
+        project.ReadFromFile(projPath);
+
+        string mainTargetGuid = project.GetUnityMainTargetGuid();
+        
+        foreach (var targetGuid in new[] { mainTargetGuid, project.GetUnityFrameworkTargetGuid() })
         {
-            string projPath = PBXProject.GetPBXProjectPath(path);
-            var project = new PBXProject();
-            project.ReadFromFile(projPath);
-
-            string mainTargetGuid = project.GetUnityMainTargetGuid();
-           
-            foreach (var targetGuid in new[] { mainTargetGuid, project.GetUnityFrameworkTargetGuid() })
-            {
-                project.SetBuildProperty(targetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "NO");
-            }
-           
-            project.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
-
-            project.WriteToFile(projPath);
-        }
-
-        private static void AddStoreKitFramework(string path)
-        {
-            string projPath = PBXProject.GetPBXProjectPath(path);
-            var project = new PBXProject();
-            project.ReadFromFile(projPath);
-            
-            string mainTargetGUID = project.GetUnityMainTargetGuid();
-            project.AddFrameworkToProject(mainTargetGUID, "StoreKit.framework", false);
-            
-            project.WriteToFile(projPath);
+            project.SetBuildProperty(targetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "NO");
         }
         
+        project.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
+
+        project.WriteToFile(projPath);
     }
+
+    private static void AddStoreKitFramework(string path)
+    {
+        string projPath = PBXProject.GetPBXProjectPath(path);
+        var project = new PBXProject();
+        project.ReadFromFile(projPath);
+        
+        string mainTargetGUID = project.GetUnityMainTargetGuid();
+        project.AddFrameworkToProject(mainTargetGUID, "StoreKit.framework", false);
+        
+        project.WriteToFile(projPath);
+    }
+    
 }
 #endif


### PR DESCRIPTION
## Motivation 
Fixes #98

## Description
Removes `namespace Editor` (which is not needed) which was colliding with a namespace named the same from Unity

## Testing Steps
1. Ran as was to make sure `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` was set to `YES`
2. Commented out code in the post install to make sure `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` was set to `NO`
3. Removed the namespace and made sure `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` was set back to `YES`
