### PR TITLE
IntegrationTests as API Tester

### DIFF
--- a/IntegrationTests/Assets/Main.cs
+++ b/IntegrationTests/Assets/Main.cs
@@ -1,18 +1,42 @@
 ﻿using UnityEngine;
 
+
+public class CustomListener : Purchases.UpdatedCustomerInfoListener
+{
+    public override void CustomerInfoReceived(Purchases.CustomerInfo customerInfo)
+    {
+        throw new System.NotImplementedException();
+    }
+}
+
 public class Main : MonoBehaviour
 {
     
     // Use this for initialization
     private void Start()
     {
-        var purchases = GetComponent<Purchases>();
+        Purchases purchases = GetComponent<Purchases>();
         purchases.SetDebugLogsEnabled(true);
+        purchases.deprecatedLegacyRevenueCatAPIKey = "abc";
+        purchases.revenueCatAPIKeyApple = "def";
+        purchases.revenueCatAPIKeyGoogle = "ghi";
+        purchases.appUserID = "abc";
+        purchases.productIdentifiers = new[] { "a", "b", "c" };
+        purchases.listener = new CustomListener();
+        purchases.observerMode = true;
+        purchases.userDefaultsSuiteName = "suitename";
+        purchases.proxyURL = "https://proxy-url.revenuecat.com";
         
+        
+        Purchases.CustomerInfo receivedCustomerInfo;
+        Purchases.Error receivedError;
         purchases.GetCustomerInfo((info, error) =>
         {
-            
+            receivedCustomerInfo = info;
+            receivedError = error;
         });
+        
+        
     }
 
 }

--- a/IntegrationTests/Assets/Main.cs
+++ b/IntegrationTests/Assets/Main.cs
@@ -9,7 +9,7 @@ public class Main : MonoBehaviour
         var purchases = GetComponent<Purchases>();
         purchases.SetDebugLogsEnabled(true);
         
-        purchases.GetPurchaserInfo((info, error) =>
+        purchases.GetCustomerInfo((info, error) =>
         {
             
         });

--- a/IntegrationTests/Assets/Main.cs
+++ b/IntegrationTests/Assets/Main.cs
@@ -9,7 +9,7 @@ public class Main : MonoBehaviour
         var purchases = GetComponent<Purchases>();
         purchases.SetDebugLogsEnabled(true);
         
-        purchases.GetCustomerInfo((info, error) =>
+        purchases.GetPurchaserInfo((info, error) =>
         {
             
         });

--- a/IntegrationTests/Assets/Main.cs
+++ b/IntegrationTests/Assets/Main.cs
@@ -1,4 +1,8 @@
-﻿using UnityEngine;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Purchasing;
 
 
 public class CustomListener : Purchases.UpdatedCustomerInfoListener
@@ -11,7 +15,6 @@ public class CustomListener : Purchases.UpdatedCustomerInfoListener
 
 public class Main : MonoBehaviour
 {
-    
     // Use this for initialization
     private void Start()
     {
@@ -26,17 +29,100 @@ public class Main : MonoBehaviour
         purchases.observerMode = true;
         purchases.userDefaultsSuiteName = "suitename";
         purchases.proxyURL = "https://proxy-url.revenuecat.com";
-        
-        
+
         Purchases.CustomerInfo receivedCustomerInfo;
         Purchases.Error receivedError;
+
+        Purchases.Package receivedPackage;
+        Purchases.Offerings receivedOfferings;
+        Purchases.Offering receivedOffering;
+        String receivedProductIdentifier;
+        bool receivedUserCancelled;
+
+        List<Purchases.StoreProduct> receivedProducts = new List<Purchases.StoreProduct>();
+
+        List<Purchases.StoreProduct> storeProducts = new List<Purchases.StoreProduct>();
+        purchases.GetProducts(new string[] { "a", "b" }, (products, error) => { receivedProducts = products; });
+
+        purchases.GetProducts(new string[] { "a", "b" }, (products, error) => { receivedProducts = products; }, "type");
+
+        purchases.GetOfferings((offerings, error) =>
+        {
+            receivedOfferings = offerings;
+            receivedError = error;
+            receivedOffering = receivedOfferings.All.First().Value;
+
+            receivedPackage = receivedOffering.AvailablePackages.First();
+            purchases.PurchasePackage(receivedPackage, (productIdentifier, customerInfo, userCancelled, error2) =>
+            {
+                receivedProductIdentifier = productIdentifier;
+                receivedCustomerInfo = customerInfo;
+                receivedUserCancelled = userCancelled;
+                receivedError = error2;
+            });
+
+            purchases.PurchasePackage(receivedPackage, (productIdentifier, customerInfo, userCancelled, error2) =>
+            {
+                receivedProductIdentifier = productIdentifier;
+                receivedCustomerInfo = customerInfo;
+                receivedUserCancelled = userCancelled;
+                receivedError = error2;
+            }, "oldSku", Purchases.ProrationMode.Deferred);
+
+            Purchases.StoreProduct storeProduct = storeProducts.First();
+            Purchases.PromotionalOffer receivedPromoOffer;
+            purchases.GetPromotionalOffer(storeProduct, storeProduct.discounts.First(), (offer, error2) =>
+            {
+                receivedPromoOffer = offer;
+                receivedError = error2;
+
+                purchases.PurchaseDiscountedPackage(receivedPackage, receivedPromoOffer,
+                    (productIdentifier, purchaserInfo, userCancelled, error3) =>
+                    {
+                        receivedProductIdentifier = productIdentifier;
+                        receivedCustomerInfo = purchaserInfo;
+                        receivedUserCancelled = userCancelled;
+                        receivedError = error3;
+                    });
+                
+                purchases.PurchaseDiscountedProduct("product_id", receivedPromoOffer,
+                    (productIdentifier, purchaserInfo, userCancelled, error3) =>
+                    {
+                        receivedProductIdentifier = productIdentifier;
+                        receivedCustomerInfo = purchaserInfo;
+                        receivedUserCancelled = userCancelled;
+                        receivedError = error3;
+                    });
+            });
+        });
+
+        purchases.PurchaseProduct("product_id", (productIdentifier, customerInfo, userCancelled, error2) =>
+        {
+            receivedProductIdentifier = productIdentifier;
+            receivedCustomerInfo = customerInfo;
+            receivedUserCancelled = userCancelled;
+            receivedError = error2;
+        });
+
+        purchases.PurchaseProduct("product_id", (productIdentifier, purchaserInfo, userCancelled, error2) =>
+        {
+            receivedProductIdentifier = productIdentifier;
+            receivedCustomerInfo = purchaserInfo;
+            receivedUserCancelled = userCancelled;
+            receivedError = error2;
+        }, "type", "oldSku", Purchases.ProrationMode.Deferred);
+
         purchases.GetCustomerInfo((info, error) =>
         {
             receivedCustomerInfo = info;
             receivedError = error;
         });
         
+        purchases.RestorePurchases((customerInfo, error) =>
+        {
+            receivedCustomerInfo = customerInfo;
+            receivedError = error;
+        });
         
     }
-
 }

--- a/IntegrationTests/Assets/Main.cs
+++ b/IntegrationTests/Assets/Main.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Purchasing;
 
 
 public class CustomListener : Purchases.UpdatedCustomerInfoListener
@@ -144,6 +143,50 @@ public class Main : MonoBehaviour
             receivedCustomerInfo = info;
             receivedError = error;
         });
+     
+        purchases.SyncPurchases();
+        purchases.SetAutomaticAppleSearchAdsAttributionCollection(true);
+        Dictionary<string, Purchases.IntroEligibility> receivedEligibilities;
+        purchases.CheckTrialOrIntroductoryPriceEligibility(new string[] { "a", "b"}, eligibilities =>
+            {
+                receivedEligibilities = eligibilities;
+            });
+        purchases.InvalidateCustomerInfoCache();
+        purchases.PresentCodeRedemptionSheet();
+        purchases.SetSimulatesAskToBuyInSandbox(true);
         
+        purchases.SetAttributes(new Dictionary<string, string>());
+        purchases.SetEmail("asdf");
+        purchases.SetPhoneNumber("asdga");
+        purchases.SetDisplayName("asdgas");
+        purchases.SetPushToken("asdgas");
+        purchases.SetAdjustID("asdgas");
+        purchases.SetAppsflyerID("asdgas");
+        purchases.SetFBAnonymousID("asdgas");
+        purchases.SetMparticleID("asdgas");
+        purchases.SetOnesignalID("asdgas");
+        purchases.SetAirshipChannelID("asdgas");
+        purchases.SetMediaSource("asdgas");
+        purchases.SetCampaign("asdgas");
+        purchases.SetAdGroup("asdgas");
+        purchases.SetAd("asdgas");
+        purchases.SetKeyword("asdgas");
+        purchases.SetCreative("asdgas");
+        purchases.CollectDeviceIdentifiers();
+        
+        bool receivedCanMakePayments = false;
+        
+        purchases.CanMakePayments((canMakePayments, error) =>
+        {
+            receivedCanMakePayments = canMakePayments;
+            receivedError = error;
+        });
+        
+        purchases.CanMakePayments(new Purchases.BillingFeature [] { Purchases.BillingFeature.Subscriptions },
+            (canMakePayments, error) =>
+            {
+                receivedCanMakePayments = canMakePayments;
+                receivedError = error;
+            });
     }
 }

--- a/IntegrationTests/Assets/Main.cs
+++ b/IntegrationTests/Assets/Main.cs
@@ -19,7 +19,6 @@ public class Main : MonoBehaviour
     private void Start()
     {
         Purchases purchases = GetComponent<Purchases>();
-        purchases.SetDebugLogsEnabled(true);
         purchases.deprecatedLegacyRevenueCatAPIKey = "abc";
         purchases.revenueCatAPIKeyApple = "def";
         purchases.revenueCatAPIKeyGoogle = "ghi";
@@ -112,15 +111,37 @@ public class Main : MonoBehaviour
             receivedError = error2;
         }, "type", "oldSku", Purchases.ProrationMode.Deferred);
 
-        purchases.GetCustomerInfo((info, error) =>
+        purchases.RestorePurchases((customerInfo, error) =>
+        {
+            receivedCustomerInfo = customerInfo;
+            receivedError = error;
+        });
+        
+        purchases.AddAttributionData("dataJson", Purchases.AttributionNetwork.BRANCH);
+        purchases.AddAttributionData("dataJson", Purchases.AttributionNetwork.BRANCH, "networkUserId");
+
+        bool receivedCreated = false;
+        purchases.LogIn("appuUerId", (info, created, error) =>
+        {
+            receivedCustomerInfo = info;
+            receivedCreated = created;
+            receivedError = error;
+        });
+        
+        purchases.LogOut((info, error) =>
         {
             receivedCustomerInfo = info;
             receivedError = error;
         });
         
-        purchases.RestorePurchases((customerInfo, error) =>
+        purchases.SetFinishTransactions(true);
+        purchases.SetAllowSharingStoreAccount(false);
+        string appUserId = purchases.GetAppUserId();
+        bool isAnonymous = purchases.IsAnonymous();
+        purchases.SetDebugLogsEnabled(true);
+        purchases.GetCustomerInfo((info, error) =>
         {
-            receivedCustomerInfo = customerInfo;
+            receivedCustomerInfo = info;
             receivedError = error;
         });
         


### PR DESCRIPTION
This PR takes advantage of the existing integration tests to use them as an API tester too. 

They work locally, but they have some issues in CI, which are caused by the fact that the export package steps uses a different version of Unity than the rest of the steps. 
I'm fixing those issues in #103 