### PR TITLE
API cleanup

### DIFF
--- a/IntegrationTests/Assets/APITests/DiscountAPITests.cs
+++ b/IntegrationTests/Assets/APITests/DiscountAPITests.cs
@@ -6,17 +6,14 @@ namespace DefaultNamespace
     {
         private void Start()
         {
-            // TODO: 
-            // properties here should be Uppercase
-            // also, they're currently read-write, but should be read-only
             Purchases.Discount discount = new Purchases.Discount(null);
-            string identifier = discount.identifier;
-            float price = discount.price;
-            string priceString = discount.priceString;
-            int cycles = discount.cycles;
-            string period = discount.period;
-            string periodUnit = discount.periodUnit;
-            int periodNumberOfUnits = discount.periodNumberOfUnits;
+            string identifier = discount.Identifier;
+            float price = discount.Price;
+            string priceString = discount.PriceString;
+            int cycles = discount.Cycles;
+            string period = discount.Period;
+            string periodUnit = discount.PeriodUnit;
+            int periodNumberOfUnits = discount.PeriodNumberOfUnits;
         }
     }
 }

--- a/IntegrationTests/Assets/APITests/ErrorAPITests.cs
+++ b/IntegrationTests/Assets/APITests/ErrorAPITests.cs
@@ -7,8 +7,6 @@ namespace DefaultNamespace
     {
         private void Start()
         {
-            // TODO: another place where properties are lowercase
-            // and readonly
             Purchases.Error error = new Purchases.Error(null);
             string message = error.Message;
             int code = error.Code;

--- a/IntegrationTests/Assets/APITests/ErrorAPITests.cs
+++ b/IntegrationTests/Assets/APITests/ErrorAPITests.cs
@@ -10,10 +10,10 @@ namespace DefaultNamespace
             // TODO: another place where properties are lowercase
             // and readonly
             Purchases.Error error = new Purchases.Error(null);
-            string message = error.message;
-            int code = error.code;
-            string underlyingErrorMessage = error.underlyingErrorMessage;
-            string readableErrorCode = error.readableErrorCode;
+            string message = error.Message;
+            int code = error.Code;
+            string underlyingErrorMessage = error.UnderlyingErrorMessage;
+            string readableErrorCode = error.ReadableErrorCode;
         }
     }
 }

--- a/IntegrationTests/Assets/APITests/PromotionalOfferAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PromotionalOfferAPITests.cs
@@ -7,13 +7,12 @@ namespace DefaultNamespace
     {
         private void Start()
         {
-            // TODO: update the properties to lowercase + readonly
             Purchases.PromotionalOffer promotionalOffer = new Purchases.PromotionalOffer(null);
-            string identifier = promotionalOffer.identifier;
-            string keyIdentifier = promotionalOffer.keyIdentifier;
-            string nonce = promotionalOffer.nonce;
-            string signature = promotionalOffer.signature;
-            long timestamp = promotionalOffer.timestamp;
+            string identifier = promotionalOffer.Identifier;
+            string keyIdentifier = promotionalOffer.KeyIdentifier;
+            string nonce = promotionalOffer.Nonce;
+            string signature = promotionalOffer.Signature;
+            long timestamp = promotionalOffer.Timestamp;
         }
     }
 }

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -74,7 +74,7 @@ public class PurchasesAPITests : MonoBehaviour
 
             Purchases.StoreProduct storeProduct = storeProducts.First();
             Purchases.PromotionalOffer receivedPromoOffer;
-            purchases.GetPromotionalOffer(storeProduct, storeProduct.discounts.First(), (offer, error2) =>
+            purchases.GetPromotionalOffer(storeProduct, storeProduct.Discounts.First(), (offer, error2) =>
             {
                 receivedPromoOffer = offer;
                 receivedError = error2;

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -16,19 +16,19 @@ public class PurchasesAPITests : MonoBehaviour
     private void Start()
     {
         Purchases purchases = GetComponent<Purchases>();
-        purchases.deprecatedLegacyRevenueCatAPIKey = "abc";
-        purchases.revenueCatAPIKeyApple = "def";
-        purchases.revenueCatAPIKeyGoogle = "ghi";
-        purchases.appUserID = "abc";
-        purchases.productIdentifiers = new[]
+        purchases.DeprecatedLegacyRevenueCatAPIKey = "abc";
+        purchases.RevenueCatAPIKeyApple = "def";
+        purchases.RevenueCatAPIKeyGoogle = "ghi";
+        purchases.AppUserID = "abc";
+        purchases.ProductIdentifiers = new[]
         {
             "a", "b", "c"
         };
 
-        purchases.listener = new CustomListener();
-        purchases.observerMode = true;
-        purchases.userDefaultsSuiteName = "suitename";
-        purchases.proxyURL = "https://proxy-url.revenuecat.com";
+        purchases.Listener = new CustomListener();
+        purchases.ObserverMode = true;
+        purchases.UserDefaultsSuiteName = "suitename";
+        purchases.ProxyURL = "https://proxy-url.revenuecat.com";
 
         Purchases.CustomerInfo receivedCustomerInfo;
         Purchases.Error receivedError;

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -15,8 +15,6 @@ public class PurchasesAPITests : MonoBehaviour
 {
     private void Start()
     {
-        // TODO: we still have a public method here called GetEntitlments, but it looks like that's 
-        // super old and should be removed
         Purchases purchases = GetComponent<Purchases>();
         purchases.deprecatedLegacyRevenueCatAPIKey = "abc";
         purchases.revenueCatAPIKeyApple = "def";

--- a/IntegrationTests/Assets/APITests/StoreProductAPITests.cs
+++ b/IntegrationTests/Assets/APITests/StoreProductAPITests.cs
@@ -7,21 +7,20 @@ namespace DefaultNamespace
     {
         private void Start()
         {
-            // todo: update to Uppercase + readonly
             Purchases.StoreProduct storeProduct = new Purchases.StoreProduct(null);
-            string title = storeProduct.title;
-            string identifier = storeProduct.identifier;
-            string description = storeProduct.description;
-            float price = storeProduct.price;
-            string priceString = storeProduct.priceString;
-            string currencyCode = storeProduct.currencyCode;
-            float introPrice = storeProduct.introPrice;
-            string introPriceString = storeProduct.introPriceString;
-            string introPricePeriod = storeProduct.introPricePeriod;
-            string introPricePeriodUnit = storeProduct.introPricePeriodUnit;
-            int introPricePeriodNumberOfUnits = storeProduct.introPricePeriodNumberOfUnits;
-            int introPriceCycles = storeProduct.introPriceCycles;
-            Purchases.Discount[] discounts = storeProduct.discounts;
+            string title = storeProduct.Title;
+            string identifier = storeProduct.Identifier;
+            string description = storeProduct.Description;
+            float price = storeProduct.Price;
+            string priceString = storeProduct.PriceString;
+            string currencyCode = storeProduct.CurrencyCode;
+            float introPrice = storeProduct.IntroPrice;
+            string introPriceString = storeProduct.IntroPriceString;
+            string introPricePeriod = storeProduct.IntroPricePeriod;
+            string introPricePeriodUnit = storeProduct.IntroPricePeriodUnit;
+            int introPricePeriodNumberOfUnits = storeProduct.IntroPricePeriodNumberOfUnits;
+            int introPriceCycles = storeProduct.IntroPriceCycles;
+            Purchases.Discount[] discounts = storeProduct.Discounts;
         }
     }
 }

--- a/IntegrationTests/Assets/APITests/StoreTransactionAPITests.cs
+++ b/IntegrationTests/Assets/APITests/StoreTransactionAPITests.cs
@@ -7,8 +7,7 @@ namespace DefaultNamespace
     {
         private void Start()
         {
-            // todo: update to read-only
-            // also, should we include the new properties?
+            // todo: should we include the new properties?
             Purchases.StoreTransaction storeTransaction = new Purchases.StoreTransaction(null);
             string revenueCatId = storeTransaction.RevenueCatId;
             string productId = storeTransaction.ProductId;

--- a/RevenueCat/Example/PurchasesListener.cs
+++ b/RevenueCat/Example/PurchasesListener.cs
@@ -36,7 +36,7 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                 {
                     Debug.Log("Package " + package);
                     if (package == null) continue;
-                    var label = package.PackageType + " " + package.StoreProduct.priceString;
+                    var label = package.PackageType + " " + package.StoreProduct.PriceString;
                     CreateButton(label, () => ButtonClicked(package), 500 + yOffset);
                     yOffset += 70;
                 }

--- a/RevenueCat/Scripts/Discount.cs
+++ b/RevenueCat/Scripts/Discount.cs
@@ -7,37 +7,37 @@ public partial class Purchases
         /// <summary>
         /// Identifier of the discount.
         /// </summary>
-        public string identifier;
+        public readonly string Identifier;
 
         /// <summary>
         /// Price in the local currency.
         /// </summary>
-        public float price;
+        public readonly float Price;
 
         /// <summary>
         /// Formatted price, including its currency sign, such as €3.99.
         /// </summary>
-        public string priceString;
+        public readonly string PriceString;
 
         /// <summary>
         /// Number of subscription billing periods for which the user will be given the discount, such as 3.
         /// </summary>
-        public int cycles;
+        public readonly int Cycles;
 
         /// <summary>
         /// Billing period of the discount, specified in ISO 8601 format.
         /// </summary>
-        public string period;
+        public readonly string Period;
 
         /// <summary>
         /// Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
         /// </summary>
-        public string periodUnit;
+        public readonly string PeriodUnit;
 
         /// <summary>
         /// Number of units for the billing period of the discount.
         /// </summary>
-        public int periodNumberOfUnits;
+        public readonly int PeriodNumberOfUnits;
 
         public Discount(JSONNode response)
         {

--- a/RevenueCat/Scripts/Discount.cs
+++ b/RevenueCat/Scripts/Discount.cs
@@ -41,24 +41,24 @@ public partial class Purchases
 
         public Discount(JSONNode response)
         {
-            identifier = response["identifier"];
-            price = response["price"];
-            priceString = response["priceString"];
-            cycles = response["cycles"];
-            period = response["period"];
-            periodUnit = response["periodUnit"];
-            periodNumberOfUnits = response["periodNumberOfUnits"];
+            Identifier = response["identifier"];
+            Price = response["price"];
+            PriceString = response["priceString"];
+            Cycles = response["cycles"];
+            Period = response["period"];
+            PeriodUnit = response["periodUnit"];
+            PeriodNumberOfUnits = response["periodNumberOfUnits"];
         }
 
         public override string ToString()
         {
-            return $"{nameof(identifier)}: {identifier}, " +
-                   $"{nameof(price)}: {price}, " +
-                   $"{nameof(priceString)}: {priceString}, " +
-                   $"{nameof(cycles)}: {cycles}, " +
-                   $"{nameof(period)}: {period}, " +
-                   $"{nameof(periodUnit)}: {periodUnit}, " +
-                   $"{nameof(periodNumberOfUnits)}: {periodNumberOfUnits}";
+            return $"{nameof(Identifier)}: {Identifier}, " +
+                   $"{nameof(Price)}: {Price}, " +
+                   $"{nameof(PriceString)}: {PriceString}, " +
+                   $"{nameof(Cycles)}: {Cycles}, " +
+                   $"{nameof(Period)}: {Period}, " +
+                   $"{nameof(PeriodUnit)}: {PeriodUnit}, " +
+                   $"{nameof(PeriodNumberOfUnits)}: {PeriodNumberOfUnits}";
         }
     }
 }

--- a/RevenueCat/Scripts/Error.cs
+++ b/RevenueCat/Scripts/Error.cs
@@ -9,25 +9,25 @@ public partial class Purchases
     [SuppressMessage("ReSharper", "NotAccessedField.Global")]
     public class Error
     {
-        public string message;
-        public int code;
-        public string underlyingErrorMessage;
-        public string readableErrorCode;
+        public readonly string Message;
+        public readonly int Code;
+        public readonly string UnderlyingErrorMessage;
+        public readonly string ReadableErrorCode;
 
         public Error(JSONNode response)
         {
-            message = response["message"];
-            code = (int) response["code"];
-            underlyingErrorMessage = response["underlyingErrorMessage"];
-            readableErrorCode = response["readableErrorCode"];
+            Message = response["message"];
+            Code = (int) response["code"];
+            UnderlyingErrorMessage = response["underlyingErrorMessage"];
+            ReadableErrorCode = response["readableErrorCode"];
         }
 
         public override string ToString()
         {
-            return $"{nameof(message)}: {message}, " +
-                   $"{nameof(code)}: {code}, " +
-                   $"{nameof(underlyingErrorMessage)}: {underlyingErrorMessage}, " +
-                   $"{nameof(readableErrorCode)}: {readableErrorCode}";
+            return $"{nameof(Message)}: {Message}, " +
+                   $"{nameof(Code)}: {Code}, " +
+                   $"{nameof(UnderlyingErrorMessage)}: {UnderlyingErrorMessage}, " +
+                   $"{nameof(ReadableErrorCode)}: {ReadableErrorCode}";
         }
     }
 }

--- a/RevenueCat/Scripts/PromotionalOffer.cs
+++ b/RevenueCat/Scripts/PromotionalOffer.cs
@@ -7,44 +7,44 @@ public partial class Purchases
         /// <summary>
         /// Identifier of the PromotionalOffer.
         /// </summary>
-        public string identifier;
+        public readonly string Identifier;
         
         /// <summary>
         ///  A string that identifies the key used to generate the signature.
         /// </summary>
-        public string keyIdentifier;
+        public readonly string KeyIdentifier;
         
         /// <summary>
         /// A universally unique ID (UUID) value that you define.
         /// </summary>
-        public string nonce;
+        public readonly string Nonce;
         
         /// <summary>
         /// A string representing the properties of a specific promotional offer, cryptographically signed.
         /// </summary>
-        public string signature;
+        public readonly string Signature;
         
         /// <summary>
         /// The date and time of the signature's creation in milliseconds, formatted in Unix epoch time.
         /// </summary>
-        public long timestamp;
+        public readonly long Timestamp;
 
         public PromotionalOffer(JSONNode response)
         {
-            identifier = response["identifier"];
-            keyIdentifier = response["keyIdentifier"];
-            nonce = response["nonce"];
-            signature = response["signature"];
-            timestamp = response["timestamp"];
+            Identifier = response["identifier"];
+            KeyIdentifier = response["keyIdentifier"];
+            Nonce = response["nonce"];
+            Signature = response["signature"];
+            Timestamp = response["timestamp"];
         }
 
         public override string ToString()
         {
-            return $"{nameof(identifier)}: {identifier}, " +
-                   $"{nameof(keyIdentifier)}: {keyIdentifier}, " +
-                   $"{nameof(nonce)}: {nonce}, " +
-                   $"{nameof(signature)}: {signature}, " +
-                   $"{nameof(timestamp)}: {timestamp}";
+            return $"{nameof(Identifier)}: {Identifier}, " +
+                   $"{nameof(KeyIdentifier)}: {KeyIdentifier}, " +
+                   $"{nameof(Nonce)}: {Nonce}, " +
+                   $"{nameof(Signature)}: {Signature}, " +
+                   $"{nameof(Timestamp)}: {Timestamp}";
         }
     }
 }

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -46,36 +46,36 @@ public partial class Purchases : MonoBehaviour
              "This property is obsolete. " +
              "Use revenueCatAPIKeyApple and revenueCatAPIKeyGoogle instead.")]
     // ReSharper disable once InconsistentNaming
-    public string deprecatedLegacyRevenueCatAPIKey;
+    public string DeprecatedLegacyRevenueCatAPIKey;
 
     [Tooltip("RevenueCat API Key specifically for Apple platforms. Get from https://app.revenuecat.com/")]
     // ReSharper disable once InconsistentNaming
-    public string revenueCatAPIKeyApple;
+    public string RevenueCatAPIKeyApple;
 
     [Tooltip("RevenueCat API Key specifically for Android. Get from https://app.revenuecat.com/")]
     // ReSharper disable once InconsistentNaming
-    public string revenueCatAPIKeyGoogle;
+    public string RevenueCatAPIKeyGoogle;
 
     [Tooltip(
         "App user id. Pass in your own ID if your app has accounts. If blank, RevenueCat will generate a user ID for you.")]
     // ReSharper disable once InconsistentNaming
-    public string appUserID;
+    public string AppUserID;
 
     [Tooltip("List of product identifiers.")]
-    public string[] productIdentifiers;
+    public string[] ProductIdentifiers;
 
     [Tooltip("A subclass of Purchases.UpdatedCustomerInfoListener component. Use your custom subclass to define how to handle updated customer information.")]
-    public UpdatedCustomerInfoListener listener;
+    public UpdatedCustomerInfoListener Listener;
 
     [Tooltip("An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.")]
-    public bool observerMode;
+    public bool ObserverMode;
 
     [Tooltip("An optional string. iOS only. Set this to use a specific NSUserDefaults suite for RevenueCat. This might be handy if you are deleting all NSUserDefaults in your app and leaving RevenueCat in a bad state.")]
-    public string userDefaultsSuiteName;
+    public string UserDefaultsSuiteName;
 
     [Header("Advanced")]
     [Tooltip("Set this property to your proxy URL before configuring Purchases *only* if you've received a proxy key value from your RevenueCat contact.")]
-    public string proxyURL;
+    public string ProxyURL;
 
     private IPurchasesWrapper _wrapper;
 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -16,8 +16,6 @@ public partial class Purchases : MonoBehaviour
 
     public delegate void LogInFunc(CustomerInfo customerInfo, bool created, Error error);
 
-    public delegate void GetEntitlementsFunc(Dictionary<string, object> entitlements, Error error);
-
     public delegate void GetOfferingsFunc(Offerings offerings, Error error);
 
     public delegate void CheckTrialOrIntroductoryPriceEligibilityFunc(Dictionary<string, IntroEligibility> products);
@@ -237,14 +235,6 @@ public partial class Purchases : MonoBehaviour
     {
         GetCustomerInfoCallback = callback;
         _wrapper.GetCustomerInfo();
-    }
-
-    private GetEntitlementsFunc GetEntitlementsCallback { get; set; }
-
-    [ObsoleteAttribute("This method has been replaced with GetOfferings.")]
-    public void GetEntitlements(GetEntitlementsFunc callback)
-    {
-
     }
 
     private GetOfferingsFunc GetOfferingsCallback { get; set; }
@@ -631,7 +621,7 @@ public partial class Purchases : MonoBehaviour
             var offeringsResponse = response["offerings"];
             GetOfferingsCallback(new Offerings(offeringsResponse), null);
         }
-        GetEntitlementsCallback = null;
+        GetOfferingsCallback = null;
     }
     
     private void _checkTrialOrIntroductoryPriceEligibility(string json)

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -88,12 +88,12 @@ public partial class Purchases : MonoBehaviour
 #else
         _wrapper = new PurchasesWrapperNoop();
 #endif
-        if (!string.IsNullOrEmpty(proxyURL))
+        if (!string.IsNullOrEmpty(ProxyURL))
         {
-            _wrapper.SetProxyURL(proxyURL);
+            _wrapper.SetProxyURL(ProxyURL);
         }
-        Setup(string.IsNullOrEmpty(appUserID) ? null : appUserID);
-        GetProducts(productIdentifiers, null);
+        Setup(string.IsNullOrEmpty(AppUserID) ? null : AppUserID);
+        GetProducts(ProductIdentifiers, null);
     }
 
     private void Setup(string newUserId)
@@ -102,15 +102,15 @@ public partial class Purchases : MonoBehaviour
 
         if (Application.platform == RuntimePlatform.IPhonePlayer
             || Application.platform == RuntimePlatform.OSXPlayer)
-            apiKey = revenueCatAPIKeyApple;
+            apiKey = RevenueCatAPIKeyApple;
         else if (Application.platform == RuntimePlatform.Android
             || IsAndroidEmulator())
-            apiKey = revenueCatAPIKeyGoogle;
+            apiKey = RevenueCatAPIKeyGoogle;
 
         if (String.IsNullOrEmpty(apiKey))
-            apiKey = deprecatedLegacyRevenueCatAPIKey;
+            apiKey = DeprecatedLegacyRevenueCatAPIKey;
 
-        _wrapper.Setup(gameObject.name, apiKey, newUserId, observerMode, userDefaultsSuiteName);
+        _wrapper.Setup(gameObject.name, apiKey, newUserId, ObserverMode, UserDefaultsSuiteName);
     }
 
     private bool IsAndroidEmulator()
@@ -507,7 +507,7 @@ public partial class Purchases : MonoBehaviour
      public void GetPromotionalOffer(StoreProduct storeProduct, Discount discount, GetPromotionalOfferFunc callback)
      {
         GetPromotionalOfferCallback = callback;
-         _wrapper.GetPromotionalOffer(storeProduct.identifier, discount.identifier);
+         _wrapper.GetPromotionalOffer(storeProduct.Identifier, discount.Identifier);
      }
      
     // ReSharper disable once UnusedMember.Local
@@ -574,12 +574,12 @@ public partial class Purchases : MonoBehaviour
     {
         Debug.Log("_receiveCustomerInfo " + customerInfoJson);
 
-        if (listener == null) return;
+        if (Listener == null) return;
 
         var response = JSON.Parse(customerInfoJson);
         if (response["customerInfo"] == null) return;
         var info = new CustomerInfo(response["customerInfo"]);
-        listener.CustomerInfoReceived(info);
+        Listener.CustomerInfoReceived(info);
     }
 
     // ReSharper disable once UnusedMember.Local

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -39,7 +39,7 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
         string discountTimestamp = null;
         if (discount != null)
         {
-            discountTimestamp = discount.timestamp.ToString();
+            discountTimestamp = discount.Timestamp.ToString();
         }
         _RCPurchaseProduct(productIdentifier, discountTimestamp);
     }
@@ -53,7 +53,7 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
         string discountTimestamp = null;
         if (discount != null)
         {
-            discountTimestamp = discount.timestamp.ToString();
+            discountTimestamp = discount.Timestamp.ToString();
         }
         _RCPurchasePackage(packageToPurchase.Identifier, packageToPurchase.OfferingIdentifier, discountTimestamp);
     }

--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -6,44 +6,44 @@ public partial class Purchases
 {
     public class StoreProduct
     {
-        public string title;
-        public string identifier;
-        public string description;
-        public float price;
-        public string priceString;
-        [CanBeNull] public string currencyCode;
-        public float introPrice;
-        public string introPriceString;
-        public string introPricePeriod;
-        public string introPricePeriodUnit;
-        public int introPricePeriodNumberOfUnits;
-        public int introPriceCycles;
+        public readonly string Title;
+        public readonly string Identifier;
+        public readonly string Description;
+        public readonly float Price;
+        public readonly string PriceString;
+        [CanBeNull] public readonly string CurrencyCode;
+        public readonly float IntroPrice;
+        public readonly string IntroPriceString;
+        public readonly string IntroPricePeriod;
+        public readonly string IntroPricePeriodUnit;
+        public readonly int IntroPricePeriodNumberOfUnits;
+        public readonly int IntroPriceCycles;
         /// <summary>
         /// Collection of iOS promotional offers for a product. Null for Android.
         /// </summary>
         /// <returns></returns>
-        [CanBeNull] public Discount[] discounts;
+        [CanBeNull] public readonly Discount[] Discounts;
             
         public StoreProduct(JSONNode response)
         {
-            title = response["title"];
-            identifier = response["identifier"];
-            description = response["description"];
-            price = response["price"];
-            priceString = response["price_string"];
-            currencyCode = response["currency_code"];
+            Title = response["title"];
+            Identifier = response["identifier"];
+            Description = response["description"];
+            Price = response["price"];
+            PriceString = response["price_string"];
+            CurrencyCode = response["currency_code"];
             var introPriceDict = response["intro_price"];
-            introPrice = introPriceDict["price"];
-            introPriceString = introPriceDict["introPriceString"];
-            introPricePeriod = introPriceDict["introPricePeriod"];
-            introPricePeriodUnit = introPriceDict["introPricePeriodUnit"];
-            introPricePeriodNumberOfUnits = introPriceDict["introPricePeriodNumberOfUnits"];
-            introPriceCycles = introPriceDict["introPriceCycles"];
+            IntroPrice = introPriceDict["price"];
+            IntroPriceString = introPriceDict["introPriceString"];
+            IntroPricePeriod = introPriceDict["introPricePeriod"];
+            IntroPricePeriodUnit = introPriceDict["introPricePeriodUnit"];
+            IntroPricePeriodNumberOfUnits = introPriceDict["introPricePeriodNumberOfUnits"];
+            IntroPriceCycles = introPriceDict["introPriceCycles"];
             
             var discountsResponse = response["discounts"];
             if (discountsResponse == null)
             {
-                discounts = null;
+                Discounts = null;
                 return;
             }
             var temporaryList = new List<Discount>();
@@ -51,24 +51,24 @@ public partial class Purchases
             {
                 temporaryList.Add(new Discount(discountResponse));
             }
-            discounts = temporaryList.ToArray();
+            Discounts = temporaryList.ToArray();
         }
 
         public override string ToString()
         {
-            return $"{nameof(title)}: {title}, " +
-                   $"{nameof(identifier)}: {identifier}, " +
-                   $"{nameof(description)}: {description}, " +
-                   $"{nameof(price)}: {price}, " +
-                   $"{nameof(priceString)}: {priceString}, " +
-                   $"{nameof(currencyCode)}: {currencyCode}, " +
-                   $"{nameof(introPrice)}: {introPrice}, " +
-                   $"{nameof(introPriceString)}: {introPriceString}, " +
-                   $"{nameof(introPricePeriod)}: {introPricePeriod}, " +
-                   $"{nameof(introPricePeriodUnit)}: {introPricePeriodUnit}, " +
-                   $"{nameof(introPricePeriodNumberOfUnits)}: {introPricePeriodNumberOfUnits}, " +
-                   $"{nameof(introPriceCycles)}: {introPriceCycles}, " +
-                   $"{nameof(discounts)}: {discounts}";
+            return $"{nameof(Title)}: {Title}, " +
+                   $"{nameof(Identifier)}: {Identifier}, " +
+                   $"{nameof(Description)}: {Description}, " +
+                   $"{nameof(Price)}: {Price}, " +
+                   $"{nameof(PriceString)}: {PriceString}, " +
+                   $"{nameof(CurrencyCode)}: {CurrencyCode}, " +
+                   $"{nameof(IntroPrice)}: {IntroPrice}, " +
+                   $"{nameof(IntroPriceString)}: {IntroPriceString}, " +
+                   $"{nameof(IntroPricePeriod)}: {IntroPricePeriod}, " +
+                   $"{nameof(IntroPricePeriodUnit)}: {IntroPricePeriodUnit}, " +
+                   $"{nameof(IntroPricePeriodNumberOfUnits)}: {IntroPricePeriodNumberOfUnits}, " +
+                   $"{nameof(IntroPriceCycles)}: {IntroPriceCycles}, " +
+                   $"{nameof(Discounts)}: {Discounts}";
         }
     }
 }

--- a/RevenueCat/Scripts/StoreTransaction.cs
+++ b/RevenueCat/Scripts/StoreTransaction.cs
@@ -12,19 +12,19 @@ public partial class Purchases
          * Id associated with the transaction in RevenueCat.
          * </summary>
          */
-        public string RevenueCatId;
+        public readonly string RevenueCatId;
         /**
          * <summary>
          * Product Id associated with the transaction.
          * </summary>
          */
-        public string ProductId;
+        public readonly string ProductId;
         /**
          * <summary>
          * Purchase date of the transaction in UTC, be sure to compare them with DateTime.UtcNow
          * </summary>
          */
-        public DateTime PurchaseDate;
+        public readonly DateTime PurchaseDate;
 
         public StoreTransaction(JSONNode response)
         {


### PR DESCRIPTION
This cleans up our API, by following C# naming standards and also making numerous properties read-only. 

We might also want to kill attributionNetwork but I'll work on that as a separate PR.