### PR TITLE
Output separate package for Unity iap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,9 +153,12 @@ jobs:
           root: .
           paths: 
             - Purchases.unitypackage
+            - Purchases-UnityIAP.unitypackage
 
       - store_artifacts:
           path: Purchases.unitypackage
+      - store_artifacts:
+          path: Purchases-UnityIAP.unitypackage
 
   build-test-android:
     executor: unity-android


### PR DESCRIPTION
Added a separate `.unityPackage` output for Unity IAP-compatible builds. 

I'm certainly not gonna win any code cleanliness awards for this one, but it should do the job, and we can clean it up as a separate thing. 