### PR TITLE
Fix error logging in subtester

### DIFF
--- a/RevenueCat/Example/PurchasesListener.cs
+++ b/RevenueCat/Example/PurchasesListener.cs
@@ -569,8 +569,8 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
 
     private void LogError(Purchases.Error error)
     {
-        Debug.Log("Subtester: " + JsonUtility.ToJson(error));
-        infoLabel.text = JsonUtility.ToJson(error);
+        Debug.Log("Subtester: " + error.ToString());
+        infoLabel.text = error.ToString();
     }
 
     private void DisplayCustomerInfo(Purchases.CustomerInfo customerInfo)


### PR DESCRIPTION
Error logging in subtester was broken. 
It was only rendering `{}` for all errors, now it correctly logs the error message to console and to the info label in sub tester