### PR TITLE
4.0.0-rc.1

### DIFF
--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -43,7 +43,7 @@ public class PurchasesWrapper {
     private static final String GET_PROMOTIONAL_OFFER = "_getPromotionalOffer";
 
     private static final String PLATFORM_NAME = "unity";
-    private static final String PLUGIN_VERSION = "4.4.0-rc.1";
+    private static final String PLUGIN_VERSION = "4.0.0-rc.1";
 
     private static String gameObject;
     private static UpdatedCustomerInfoListener listener = new UpdatedCustomerInfoListener() {


### PR DESCRIPTION
## 4.0.0-rc.1
⚠️ ⚠️ Important ⚠️ ⚠️ Observer mode for Amazon is not supported yet.

⚠️ ⚠️ Important ⚠️ ⚠️ In order to use Unity IAP with RevenueCat in Observer mode,
you need to use the `Purchases-UnityIAP.unityPackage`.

For Amazon installation instructions please follow take a look at the [Amazon instructions document](https://github.com/RevenueCat/purchases-unity/blob/4.0.0-rc.1/AMAZON-INSTRUCTIONS.md)

### Features

#### Amazon Appstore Support
We have introduced support for using the Amazon Appstore. We have extensively tested this, and there are some apps using our pre-release Amazon versions in production.

However, we have found some inconsistencies in the way Amazon Appstore prices are reported. We are actively working on patching these inconsistencies.

Please help us help you by reporting any issues you find. [New RevenueCat Issue](https://github.com/RevenueCat/purchases-unity/issues/new/).

You can enable Amazon Appstore support by configuring the SDK using the new `RevenueCatAPIKeyAmazon` field.

For more information around configuration please take a look at the [Amazon Appstore section in our docs](https://docs.revenuecat.com/docs/amazon-platform-resources). The official [Amazon In-App Purchasing docs](https://developer.amazon.com/docs/in-app-purchasing/iap-overview.html) also contain very valuable information, especially around testing and best practices.

#### StoreKit 2 support
This version of the SDK automatically uses StoreKit 2 APIs under the hood only for APIs that the RevenueCat team has determined work better than StoreKit 1. 

#### New types and cleaned up naming
New types that wrap native types from Apple, Google and Amazon, and we cleaned up the naming of other types and methods for a more consistent experience. 

### Removed APIs
- `Identify` and `CreateAlias` have been removed in favor of `LogIn`.
- `Reset` has been removed in favor of `LogOut`.
- `GetEntitlements` has been removed in favor of `GetOfferings`.
- `AttributionKey` and `Purchases.AddAttributionData` have been removed in favor of `Set<NetworkID> methods`.
- `revenueCatAPIKey` has been removed in favor of `revenueCatAPIKeyApple`, `revenueCatAPIKeyGoogle` and `revenueCatAPIKeyAmazon`.

### Renamed APIs

| 3.x | 4.0.0 |
| :-: | :-: |
| `PurchaserInfo` | `CustomerInfo` |
| `Transaction` | `StoreTransaction` |
| `Product` | `StoreProduct` |
| `PaymentDiscount` | `PromotionalOffer` |
| `Purchases.RestoreTransactions` | `Purchases.RestorePurchases` |
| `Purchases.GetPaymentDiscount` | `Purchases.GetPromotionalOffer` |
| `Purchases.UpdatedPurchaserInfoListener` | `Purchases.UpdatedCustomerInfoListener` |
| `Discount.identifier` | `Discount.Identifier` |
| `Discount.price` | `Discount.Price` |
| `Discount.priceString` | `Discount.PriceString` |
| `Discount.cycles` | `Discount.Cycles` |
| `Discount.period` | `Discount.Period` |
| `Discount.unit` | `Discount.Unit` |
| `Discount.periodUnit` | `Discount.PeriodUnit` |
| `Discount.periodNumberOfUnits` | `Discount.PeriodNumberOfUnits` |
| `Error.message` | `Error.Message` |
| `Error.code` | `Error.Code` |
| `Error.underlyingErrorMessage` | `Error.UnderlyingErrorMessage` |
| `Error.readableErrorCode` | `Error.ReadableErrorCode` |