### PR TITLE
Update AMAZON-INSTRUCTIONS.md

### DIFF
--- a/AMAZON-INSTRUCTIONS.md
+++ b/AMAZON-INSTRUCTIONS.md
@@ -1,12 +1,12 @@
 This release adds pre-release support for Amazon store. 
 
 ## Instructions
-- Download the `Purchases-UnityIAP.unitypackage` in the release
+- Download the `Purchases.unitypackage` (`Purchases-UnityIAP.unitypackage` if using in observer mode) in the release.
 - Open your Unity Project
 - Select Import package -> Custom package
 <img width="471" alt="Screen Shot 2021-11-24 at 3 55 50 PM" src="https://user-images.githubusercontent.com/664544/143326927-764cb381-30a7-4d8d-8f3a-3c45c1e9d67f.png">
 
-- Select Purchases_Amazon.unityPackage and make sure all of the files are selected and press import
+- Select Purchases.unitypackage (or `Purchases-UnityIAP.unitypackage`) and make sure all of the files are selected and press import
 
 <img width="472" alt="Screen Shot 2021-11-24 at 3 56 10 PM" src="https://user-images.githubusercontent.com/664544/143326950-ec8d5993-cd9e-468a-9a9a-27fee8a63519.png">
 
@@ -28,7 +28,7 @@ Due to some limitations, RevenueCat will only validate purchases made in product
 
 ## Observer mode specific
 
-- If your app also targets the Google Play Store, you will want to conditionally exclude the BillingClient to prevent duplicated classes. If you don't have a `mainTemplate.gradle`, make sure you have `Custom Main Gradle Template` selected in the `Android Player Settings`, which should create a `mainTemplate.gradle` inside the Assets/Plugins/Android.  Add the following to your `mainTemplate.gradle` to prevent duplicated classes when Unity IAP is targeting the Play Store:
+- If your app also uses the BillingClient via another plugin like Unity IAP, you will want to conditionally exclude the BillingClient to prevent duplicated classes. If you don't have a `mainTemplate.gradle`, make sure you have `Custom Main Gradle Template` selected in the `Android Player Settings`, which should create a `mainTemplate.gradle` inside the Assets/Plugins/Android.  Add the following to your `mainTemplate.gradle` to prevent duplicated classes when Unity IAP is targeting the Play Store:
 
 ```
 dependencies {


### PR DESCRIPTION
I tested an observer mode installation and updated the Amazon instructions since some things were not correct. 

We still need to fix [CSDK-335](https://revenuecats.atlassian.net/browse/CSDK-335) so excluding the billingclient is not needed anymore.