### PR TITLE
rename `Setup` to `Configure`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - export-package: *release-tags-and-branches
+      # - export-package: *release-tags-and-branches
+      - export-package
       - build-test-android:
           <<:  *release-tags-and-branches
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,8 +242,7 @@ workflows:
   version: 2
   build:
     jobs:
-      # - export-package: *release-tags-and-branches
-      - export-package
+      - export-package: *release-tags-and-branches
       - build-test-android:
           <<:  *release-tags-and-branches
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-rc.3
+
+- Deprecated `Purchases.Setup` in favor of `Purchases.Configure`.
+
 ## 4.0.0-rc.2
 
 ### New changes since Release Candidate 1

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -189,5 +189,15 @@ public class PurchasesAPITests : MonoBehaviour
                 receivedCanMakePayments = canMakePayments;
                 receivedError = error;
             });
+
+        Purchases.PurchasesConfiguration.Builder builder = Purchases.PurchasesConfiguration.Builder.Init("api_key");
+        Purchases.PurchasesConfiguration purchasesConfiguration =
+            builder.SetUserDefaultsSuiteName("user_default")
+            .SetDangerousSettings(new Purchases.DangerousSettings(false))
+            .SetObserverMode(true)
+            .SetUseAmazon(false)
+            .SetAppUserId(appUserId)
+            .Build();
+        purchases.Configure(purchasesConfiguration);
     }
 }

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -44,18 +44,22 @@ public partial class Purchases : MonoBehaviour
     [Tooltip("Activate if you plan to call Purchases.Configure or Purchases.Setup programmatically.")]
     public bool useRuntimeSetup;
 
-    [Tooltip("RevenueCat API Key specifically for Apple platforms. Get from https://app.revenuecat.com/")]
+    [Tooltip("RevenueCat API Key specifically for Apple platforms. Get from https://app.revenuecat.com/ " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public string revenueCatAPIKeyApple;
 
-    [Tooltip("RevenueCat API Key specifically for Google Play. Get from https://app.revenuecat.com/")]
+    [Tooltip("RevenueCat API Key specifically for Google Play. Get from https://app.revenuecat.com/ " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public string revenueCatAPIKeyGoogle;
 
     [Header("Alternative Stores")]
-    [Tooltip("RevenueCat API Key specifically for Amazon Appstore. Get from https://app.revenuecat.com/")]
+    [Tooltip("RevenueCat API Key specifically for Amazon Appstore. Get from https://app.revenuecat.com/ " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public string revenueCatAPIKeyAmazon;
 
     [Tooltip("Enables Amazon Store support. Android only, on iOS it has no effect." +
-             "If enabled, it will use the API key in RevenueCatAPIKeyAmazon.")]
+             "If enabled, it will use the API key in RevenueCatAPIKeyAmazon. " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public bool useAmazon;
 
     [Header("Dangerous Settings")]
@@ -65,32 +69,38 @@ public partial class Purchases : MonoBehaviour
              "RevenueCat's backend. " +
              "In iOS, consumables disappear from the receipt after the transaction is finished, so make sure purchases " +
              "are synced before finishing any consumable transaction, otherwise RevenueCat won't register the purchase. " +
-             "Auto syncing of purchases is enabled by default.")]
+             "Auto syncing of purchases is enabled by default. " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public bool autoSyncPurchases = true;
 
-    [Tooltip(
-        "App user id. Pass in your own ID if your app has accounts. If blank, RevenueCat will generate a user ID for you.")]
+    [Tooltip("App user id. Pass in your own ID if your app has accounts. " +
+             "If blank, RevenueCat will generate a user ID for you. " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     // ReSharper disable once InconsistentNaming
     public string appUserID;
 
     [Tooltip("List of product identifiers.")]
     public string[] productIdentifiers;
 
-    [Tooltip(
-        "A subclass of Purchases.UpdatedCustomerInfoListener component. Use your custom subclass to define how to handle updated customer information.")]
+    [Tooltip("A subclass of Purchases.UpdatedCustomerInfoListener component. " +
+             "Use your custom subclass to define how to handle updated customer information.")]
     public UpdatedCustomerInfoListener listener;
 
-    [Tooltip(
-        "An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.")]
+    [Tooltip("An optional boolean. Set this to true if you have your own IAP implementation " +
+             "and want to use only RevenueCat's backend. Default is false. " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public bool observerMode;
 
-    [Tooltip(
-        "An optional string. iOS only. Set this to use a specific NSUserDefaults suite for RevenueCat. This might be handy if you are deleting all NSUserDefaults in your app and leaving RevenueCat in a bad state.")]
+    [Tooltip("An optional string. iOS only. Set this to use a specific NSUserDefaults suite for RevenueCat. " +
+             "This might be handy if you are deleting all NSUserDefaults in your app " +
+             "and leaving RevenueCat in a bad state. " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public string userDefaultsSuiteName;
 
     [Header("Advanced")]
-    [Tooltip(
-        "Set this property to your proxy URL before configuring Purchases *only* if you've received a proxy key value from your RevenueCat contact.")]
+    [Tooltip("Set this property to your proxy URL before configuring Purchases *only* if you've received " +
+             "a proxy key value from your RevenueCat contact. " +
+             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
     public string proxyURL;
 
     private IPurchasesWrapper _wrapper;

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -44,63 +44,73 @@ public partial class Purchases : MonoBehaviour
     [Tooltip("Activate if you plan to call Purchases.Configure or Purchases.Setup programmatically.")]
     public bool useRuntimeSetup;
 
-    [Tooltip("RevenueCat API Key specifically for Apple platforms. Get from https://app.revenuecat.com/ " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+    [Tooltip("RevenueCat API Key specifically for Apple platforms.\nGet from https://app.revenuecat.com/ \n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public string revenueCatAPIKeyApple;
 
-    [Tooltip("RevenueCat API Key specifically for Google Play. Get from https://app.revenuecat.com/ " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+    [Tooltip("RevenueCat API Key specifically for Google Play.\nGet from https://app.revenuecat.com/ \n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public string revenueCatAPIKeyGoogle;
 
     [Header("Alternative Stores")]
-    [Tooltip("RevenueCat API Key specifically for Amazon Appstore. Get from https://app.revenuecat.com/ " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+    [Tooltip("RevenueCat API Key specifically for Amazon Appstore.\nGet from https://app.revenuecat.com/ \n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public string revenueCatAPIKeyAmazon;
 
-    [Tooltip("Enables Amazon Store support. Android only, on iOS it has no effect." +
-             "If enabled, it will use the API key in RevenueCatAPIKeyAmazon. " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+    [Tooltip("Enables Amazon Store support. Android only, on iOS it has no effect.\n" +
+             "If enabled, it will use the API key in RevenueCatAPIKeyAmazon.\n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public bool useAmazon;
 
     [Header("Dangerous Settings")]
-    [Tooltip("Disable or enable automatically detecting current subscriptions." +
+    [Tooltip("Disable or enable automatically detecting current subscriptions.\n" +
              "If this is disabled, RevenueCat won't check current purchases, and it will not sync any purchase automatically " +
-             "when the app starts. Call syncPurchases whenever a new purchase is detected so the receipt is sent to " +
-             "RevenueCat's backend. " +
+             "when the app starts.\nCall syncPurchases whenever a new purchase is detected so the receipt is sent to " +
+             "RevenueCat's backend.\n" +
              "In iOS, consumables disappear from the receipt after the transaction is finished, so make sure purchases " +
-             "are synced before finishing any consumable transaction, otherwise RevenueCat won't register the purchase. " +
-             "Auto syncing of purchases is enabled by default. " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+             "are synced before finishing any consumable transaction, otherwise RevenueCat won't register the purchase.\n" +
+             "Auto syncing of purchases is enabled by default.\n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public bool autoSyncPurchases = true;
 
-    [Tooltip("App user id. Pass in your own ID if your app has accounts. " +
-             "If blank, RevenueCat will generate a user ID for you. " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+    [Tooltip("App user id. Pass in your own ID if your app has accounts.\n" +
+             "If blank, RevenueCat will generate a user ID for you.\n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     // ReSharper disable once InconsistentNaming
     public string appUserID;
 
     [Tooltip("List of product identifiers.")]
     public string[] productIdentifiers;
 
-    [Tooltip("A subclass of Purchases.UpdatedCustomerInfoListener component. " +
+    [Tooltip("A subclass of Purchases.UpdatedCustomerInfoListener component.\n" +
              "Use your custom subclass to define how to handle updated customer information.")]
     public UpdatedCustomerInfoListener listener;
 
     [Tooltip("An optional boolean. Set this to true if you have your own IAP implementation " +
-             "and want to use only RevenueCat's backend. Default is false. " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+             "and want to use only RevenueCat's backend.\nDefault is false.\n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public bool observerMode;
 
-    [Tooltip("An optional string. iOS only. Set this to use a specific NSUserDefaults suite for RevenueCat. " +
+    [Tooltip("An optional string. iOS only.\n" +
+             "Set this to use a specific NSUserDefaults suite for RevenueCat. " +
              "This might be handy if you are deleting all NSUserDefaults in your app " +
-             "and leaving RevenueCat in a bad state. " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+             "and leaving RevenueCat in a bad state.\n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public string userDefaultsSuiteName;
 
     [Header("Advanced")]
     [Tooltip("Set this property to your proxy URL before configuring Purchases *only* if you've received " +
-             "a proxy key value from your RevenueCat contact. " +
-             "Note: This value not be used if Purchases.useRuntimeSetup is true.")]
+             "a proxy key value from your RevenueCat contact.\n" +
+             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
+             "it through PurchasesConfiguration instead")]
     public string proxyURL;
 
     private IPurchasesWrapper _wrapper;

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -143,6 +143,7 @@ public partial class Purchases : MonoBehaviour
         Configure(purchasesConfiguration);
     }
     
+    // ReSharper disable once MemberCanBePrivate.Global
     public void Configure(PurchasesConfiguration purchasesConfiguration)
     {
         var dangerousSettings = purchasesConfiguration.DangerousSettings.Serialize().ToString();

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -41,7 +41,7 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     public delegate void GetPromotionalOfferFunc(PromotionalOffer promotionalOffer, Error error);
 
-    [Tooltip("Activate if you plan to call Purchases.Setup programmatically.")]
+    [Tooltip("Activate if you plan to call Purchases.Configure or Purchases.Setup programmatically.")]
     public bool useRuntimeSetup;
 
     [Tooltip("RevenueCat API Key specifically for Apple platforms. Get from https://app.revenuecat.com/")]
@@ -111,11 +111,11 @@ public partial class Purchases : MonoBehaviour
 
         if (useRuntimeSetup) return;
 
-        Setup(string.IsNullOrEmpty(appUserID) ? null : appUserID);
+        Configure(string.IsNullOrEmpty(appUserID) ? null : appUserID);
         GetProducts(productIdentifiers, null);
     }
 
-    private void Setup(string newUserId)
+    private void Configure(string newUserId)
     {
         var apiKey = "";
 
@@ -134,10 +134,16 @@ public partial class Purchases : MonoBehaviour
             .SetUseAmazon(useAmazon)
             .SetDangerousSettings(dangerousSettings);
 
-        Setup(builder.Build());
+        Configure(builder.Build());
     }
 
+    [Obsolete("Deprecated, use Configure instead.", false)]
     public void Setup(PurchasesConfiguration purchasesConfiguration)
+    {
+        Configure(purchasesConfiguration);
+    }
+    
+    public void Configure(PurchasesConfiguration purchasesConfiguration)
     {
         var dangerousSettings = purchasesConfiguration.DangerousSettings.Serialize().ToString();
         _wrapper.Setup(gameObject.name, purchasesConfiguration.ApiKey, purchasesConfiguration.AppUserId,

--- a/RevenueCat/Scripts/PurchasesConfiguration.cs
+++ b/RevenueCat/Scripts/PurchasesConfiguration.cs
@@ -52,6 +52,7 @@ public partial class Purchases
 
             public PurchasesConfiguration Build()
             {
+                _dangerousSettings ??= new DangerousSettings(false);
                 return new PurchasesConfiguration(_apiKey, _appUserId, _observerMode, _userDefaultsSuiteName,
                     _useAmazon, _dangerousSettings);
             }

--- a/RevenueCat/Scripts/PurchasesConfiguration.cs
+++ b/RevenueCat/Scripts/PurchasesConfiguration.cs
@@ -1,5 +1,10 @@
 public partial class Purchases
 {
+    /// <summary>
+    /// Class used to configure the SDK programmatically.
+    /// Create a configuration builder, set its properties, then call `Build` to obtain the configuration.
+    /// Lastly, call Purchases.Configure and with the obtained PurchasesConfiguration object.
+    /// </summary>
     public class PurchasesConfiguration
     {
         public readonly string ApiKey;
@@ -20,6 +25,12 @@ public partial class Purchases
             DangerousSettings = dangerousSettings;
         }
 
+        /// <summary>
+        /// Use this object to create a PurchasesConfiguration object that can be used to configure
+        /// the SDK programmatically. 
+        /// Create a configuration builder, set its properties, then call `Build` to obtain the configuration.
+        /// Lastly, call Purchases.Configure and with the obtained PurchasesConfiguration object.
+        /// </summary>
         public class Builder
         {
             private readonly string _apiKey;


### PR DESCRIPTION
Renamed `Setup` to `Configure`. 

I added a deprecation to `Setup` although it was never technically public in a non-prerelease build, because it doesn't hurt to have it and it'll make it slightly easier for anyone who was using a pre-release build to update. 