### PR TITLE
Fix: crash when cancelling

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -69,7 +69,7 @@ char *makeStringCopy(NSString *nstring) {
                userDefaultsSuiteName:userDefaultsSuiteName
                       platformFlavor:self.platformFlavor
                platformFlavorVersion:self.platformFlavorVersion
-            usesStoreKit2IfAvailable:true
+            usesStoreKit2IfAvailable:false
                    dangerousSettings:nil];
     
     self.gameObject = gameObject;


### PR DESCRIPTION
There's a crash when cancelling purchases, due to a difference in behavior between SK1 and SK2. 

Ideally we'd improve behavior to unify between them, but in the meantime, this SDK has been thoroughly tested with SK1, not with SK2, so using SK1 is safer. 