### PR TITLE
Subtester: Fix unity android export

### DIFF
--- a/Subtester/Assets/Plugins/Android/baseProjectTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/baseProjectTemplate.gradle
@@ -1,0 +1,29 @@
+allprojects {
+    buildscript {
+        repositories {**ARTIFACTORYREPOSITORY**
+            google()
+            jcenter()
+        }
+
+        dependencies {
+            // If you are changing the Android Gradle Plugin version, make sure it is compatible with the Gradle version preinstalled with Unity
+            // See which Gradle version is preinstalled with Unity here https://docs.unity3d.com/Manual/android-gradle-overview.html
+            // See official Gradle and Android Gradle Plugin compatibility table here https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+            // To specify a custom Gradle version in Unity, go do "Preferences > External Tools", uncheck "Gradle Installed with Unity (recommended)" and specify a path to a custom Gradle version
+            classpath 'com.android.tools.build:gradle:7.0.2'
+            **BUILD_SCRIPT_DEPS**
+        }
+    }
+
+    repositories {**ARTIFACTORYREPOSITORY**
+        google()
+        jcenter()
+        flatDir {
+            dirs "${project(':unityLibrary').projectDir}/libs"
+        }
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/Subtester/Assets/Plugins/Android/baseProjectTemplate.gradle.meta
+++ b/Subtester/Assets/Plugins/Android/baseProjectTemplate.gradle.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8a8ba879791614aa28b2e85869d94c7b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/Plugins/Android/gradleTemplate.properties
+++ b/Subtester/Assets/Plugins/Android/gradleTemplate.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx**JVM_HEAP_SIZE**M
 org.gradle.parallel=true
-android.enableR8=**MINIFY_WITH_R_EIGHT**
 unityStreamingAssets=**STREAMING_ASSETS**
 # Android Resolver Properties Start
 android.useAndroidX=true

--- a/Subtester/ProjectSettings/ProjectSettings.asset
+++ b/Subtester/ProjectSettings/ProjectSettings.asset
@@ -163,7 +163,7 @@ PlayerSettings:
     tvOS: 0
   overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 97
-  AndroidMinSdkVersion: 29
+  AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 31
   AndroidPreferredInstallLocation: 1
   aotOptions: 

--- a/Subtester/ProjectSettings/ProjectSettings.asset
+++ b/Subtester/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1
+  bundleVersion: 97
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -145,11 +145,13 @@ PlayerSettings:
     enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
   enableFrameTimingStats: 0
+  enableOpenGLProfilerGPURecorders: 1
   useHDRDisplay: 0
   D3DHDRBitDepth: 0
   m_ColorGamuts: 00000000
   targetPixelDensity: 30
   resolutionScalingMode: 0
+  resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
@@ -160,9 +162,9 @@ PlayerSettings:
     iPhone: 0
     tvOS: 0
   overrideDefaultApplicationIdentifier: 0
-  AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 22
-  AndroidTargetSdkVersion: 0
+  AndroidBundleVersionCode: 97
+  AndroidMinSdkVersion: 29
+  AndroidTargetSdkVersion: 31
   AndroidPreferredInstallLocation: 1
   aotOptions: 
   stripEngineCode: 1
@@ -241,7 +243,7 @@ PlayerSettings:
   useCustomLauncherManifest: 0
   useCustomMainGradleTemplate: 1
   useCustomLauncherGradleManifest: 0
-  useCustomBaseGradleTemplate: 0
+  useCustomBaseGradleTemplate: 1
   useCustomGradlePropertiesTemplate: 1
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 1
@@ -841,6 +843,7 @@ PlayerSettings:
   metroFTAName: 
   metroFTAFileTypes: []
   metroProtocolName: 
+  vcxProjDefaultLanguage: 
   XboxOneProductId: 
   XboxOneUpdateKey: 
   XboxOneSandboxId: 


### PR DESCRIPTION
Exporting SubTester for Android was getting pretty annoying: 

Process before: 
- Export project
- Go to project, update gradle version to 7.0.2
- Go to gradle.properties and remove the `enableR8` line
- Go to build.gradle for the project and update the compile sdk to 31
- Go to the android manifest for the unity framework and add android:exported
- Done! Ready to run. 

Process after: 
- Export project
- Select Cancel when you see this annoying message that I couldn't find a way around from Unity. Clicking cancel will still export the project. 
<img width="274" alt="image" src="https://user-images.githubusercontent.com/3922667/186925205-08d731d8-604c-4d1f-9723-6a94bfe01e1f.png">
- Done! Ready to run. 

Ideas and suggestions for the last prompt from Unity are welcome. 

Also, this fixes a bug in the purchase buttons where they might show up off screen because I refactored code and forgot to re-test 🤦 