### PR TITLE
Bump PHC to 4.2.1

### DIFF
--- a/IntegrationTests/Assets/APITests/StoreTransactionAPITests.cs
+++ b/IntegrationTests/Assets/APITests/StoreTransactionAPITests.cs
@@ -8,7 +8,9 @@ namespace DefaultNamespace
         private void Start()
         {
             Purchases.StoreTransaction storeTransaction = new Purchases.StoreTransaction(null);
+            string transactionIdentifier = storeTransaction.TransactionIdentifier;
             string revenueCatId = storeTransaction.RevenueCatId;
+            string productIdentifier = storeTransaction.ProductIdentifier;
             string productId = storeTransaction.ProductId;
             DateTime purchaseDate = storeTransaction.PurchaseDate;
         }

--- a/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
+++ b/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[4.1.2]" />
+        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[4.2.1]" />
         <androidPackage spec="androidx.annotation:annotation:[1.2.0]" />
     </androidPackages>
     <iosPods>
-        <iosPod name="PurchasesHybridCommon" version="4.1.2" minTargetSdk="11.0"/>
+        <iosPod name="PurchasesHybridCommon" version="4.2.1" minTargetSdk="11.0"/>
     </iosPods>
 </dependencies>

--- a/RevenueCat/Scripts/StoreTransaction.cs
+++ b/RevenueCat/Scripts/StoreTransaction.cs
@@ -51,7 +51,7 @@ public partial class Purchases
 
         public StoreTransaction(JSONNode response)
         {
-            TransactionIdentifier = response["transactionIdentifier"]
+            TransactionIdentifier = response["transactionIdentifier"];
             RevenueCatId = response["transactionIdentifier"];
             ProductIdentifier = response["productIdentifier"];
             ProductId = response["productIdentifier"];

--- a/RevenueCat/Scripts/StoreTransaction.cs
+++ b/RevenueCat/Scripts/StoreTransaction.cs
@@ -4,7 +4,7 @@ using static RevenueCat.Utilities;
 
 
 public partial class Purchases
-{    
+{
     /// <summary>
     /// Abstract class that provides access to properties of a transaction. StoreTransactions can represent
     /// transactions from StoreKit 1, StoreKit 2 or transactions made from other places,
@@ -17,13 +17,31 @@ public partial class Purchases
          * Id associated with the transaction in RevenueCat.
          * </summary>
          */
+        [Obsolete("Deprecated, use TransactionIdentifier instead.", false)]
         public readonly string RevenueCatId;
+
+        /**
+         * <summary>
+         * Id associated with the transaction in RevenueCat.
+         * </summary>
+         */
+        public readonly string TransactionIdentifier;
+
         /**
          * <summary>
          * Product Id associated with the transaction.
          * </summary>
          */
+        [Obsolete("Deprecated, use ProductIdentifier instead.", false)]
         public readonly string ProductId;
+
+        /**
+         * <summary>
+         * Product Id associated with the transaction.
+         * </summary>
+         */
+        public readonly string ProductIdentifier;
+
         /**
          * <summary>
          * Purchase date of the transaction in UTC, be sure to compare them with DateTime.UtcNow
@@ -33,14 +51,18 @@ public partial class Purchases
 
         public StoreTransaction(JSONNode response)
         {
-            RevenueCatId = response["revenueCatId"];
-            ProductId = response["productId"];
+            TransactionIdentifier = response["transactionIdentifier"]
+            RevenueCatId = response["transactionIdentifier"];
+            ProductIdentifier = response["productIdentifier"];
+            ProductId = response["productIdentifier"];
             PurchaseDate = FromUnixTimeInMilliseconds(response["purchaseDateMillis"].AsLong);
-        } 
-        
+        }
+
         public override string ToString()
         {
-            return $"{nameof(RevenueCatId)}: {RevenueCatId}\n" +
+            return $"{nameof(TransactionIdentifier)}: {TransactionIdentifier}\n" +
+                   $"{nameof(RevenueCatId)}: {RevenueCatId}\n" +
+                   $"{nameof(ProductIdentifier)}: {ProductIdentifier}\n" +
                    $"{nameof(ProductId)}: {ProductId}\n" +
                    $"{nameof(PurchaseDate)}: {PurchaseDate}";
         }

--- a/Subtester/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/mainTemplate.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
     implementation 'androidx.annotation:annotation:[1.2.0]' // Assets/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml:5
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:[4.1.2]' // Assets/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml:4
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:[4.2.1]' // Assets/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml:4
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/Subtester/ProjectSettings/AndroidResolverDependencies.xml
+++ b/Subtester/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,7 +1,7 @@
 <dependencies>
   <packages>
     <package>androidx.annotation:annotation:[1.2.0]</package>
-    <package>com.revenuecat.purchases:purchases-hybrid-common:[4.1.2]</package>
+    <package>com.revenuecat.purchases:purchases-hybrid-common:[4.2.1]</package>
   </packages>
   <files />
   <settings>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,15 +60,6 @@ lane :prepare_next_version do |options|
   )
 end
 
-desc "Creates GitHub release and publishes package"
-lane :release do |options|
-  version_number = current_version_number
-  Dir.chdir(get_root_folder) do
-    sh('npm', 'publish')
-  end
-  github_release(version: version_number)
-end
-
 desc "Update hybrid common pod and gradle"
 lane :update_hybrid_common_versions do |options|
   if options[:dry_run]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,6 +60,15 @@ lane :prepare_next_version do |options|
   )
 end
 
+desc "Creates GitHub release and publishes package"
+lane :release do |options|
+  version_number = current_version_number
+  Dir.chdir(get_root_folder) do
+    sh('npm', 'publish')
+  end
+  github_release(version: version_number)
+end
+
 desc "Update hybrid common pod and gradle"
 lane :update_hybrid_common_versions do |options|
   if options[:dry_run]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,7 +89,7 @@ lane :update_hybrid_common_versions do |options|
   UI.message("ℹ️  Setting Purchases Hybrid Common version: #{new_version_number}")
   files_to_update = [
     'RevenueCat/Plugins/Editor/RevenueCatDependencies.xml',
-    'Subtester/Assets/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml',
+    'Subtester/Assets/Plugins/Android/mainTemplate.gradle',
     'Subtester/ProjectSettings/AndroidResolverDependencies.xml'
   ]
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -37,6 +37,14 @@ Make github release
 
 Creates PR changing version to next minor adding a -SNAPSHOT suffix
 
+### release
+
+```sh
+[bundle exec] fastlane release
+```
+
+Creates GitHub release and publishes package
+
 ### update_hybrid_common_versions
 
 ```sh

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -37,14 +37,6 @@ Make github release
 
 Creates PR changing version to next minor adding a -SNAPSHOT suffix
 
-### release
-
-```sh
-[bundle exec] fastlane release
-```
-
-Creates GitHub release and publishes package
-
 ### update_hybrid_common_versions
 
 ```sh


### PR DESCRIPTION
This PR bumps PHC to 4.2.1. As part of that change, we have added `TransactionIdentifier` and `ProductIdentifier` to `StoreTransaction` while deprecating the old `RevenueCatId` and `ProductId`.

This PR also contains a couple of small fixes for the release automation process.
