### PR TITLE
Add workspace artifcats to github-release job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,8 @@ jobs:
       - image: cimg/ruby:3.1.2
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - revenuecat/trust-github-key


### PR DESCRIPTION
This fixes an issue where the `github_release` fastlane job could not find the unitypackage artifacts. It was missing a step to actually bring those in.
