### PR TITLE
Move to SNAPSHOT version on every commit to main if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,13 @@ aliases:
       branches:
         ignore: /.*/
 
+  only-main-branch: &only-main-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only: main
+
 orbs:
   revenuecat: revenuecat/sdks-common-config@2.0.0
 
@@ -306,7 +313,11 @@ workflows:
           <<: *release-tags
           requires:
             - export-package
+
+  snapshot-bump:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
       - prepare-next-version:
-          <<: *release-tags
-          requires:
-            - github-release
+          <<: *only-main-branch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 562dbc8d71bba33ec58b5c999d15e4c39b09bc7f
+  revision: 1269f49ad16be4fc7b38ff8b75e17f819f6af6c8
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 


### PR DESCRIPTION
### Description
This PR updates the fastlane plugin to include https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/31. With this, every time we commit to `main`, if the version is not a SNAPSHOT, it will create a PR updating to the next SNAPSHOT version. Additionally, I moved this job to a different workflow to keep the `deploy` workflow a bit more tidy.
