### PR TITLE
Fix support for DangerousSettings in iOS

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -70,7 +70,7 @@ usesStoreKit2IfAvailable:(BOOL)usesStoreKit2IfAvailable
                                                                           options:0
                                                                             error:&error];
 
-    RCDangerousSettings *dangerousSettings = NULL;
+    RCDangerousSettings *dangerousSettings = nil;
 
     if (error) {
         NSLog(@"Error parsing dangerousSettings JSON: %@ %@", dangerousSettingsJson, error.localizedDescription);

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -60,9 +60,24 @@ char *makeStringCopy(NSString *nstring) {
             gameObject:(NSString *)gameObject
           observerMode:(BOOL)observerMode
 usesStoreKit2IfAvailable:(BOOL)usesStoreKit2IfAvailable
- userDefaultsSuiteName:(nullable NSString *)userDefaultsSuiteName {
+ userDefaultsSuiteName:(nullable NSString *)userDefaultsSuiteName
+ dangerousSettingsJson:(NSString *)dangerousSettingsJson {
     self.products = nil;
     self.gameObject = nil;
+
+    NSError *error = nil;
+    NSDictionary *dangerousSettingsDict = [NSJSONSerialization JSONObjectWithData:[dangerousSettingsJson dataUsingEncoding:NSUTF8StringEncoding]
+                                                                          options:0
+                                                                            error:&error];
+
+    RCDangerousSettings *dangerousSettings = NULL;
+
+    if (error) {
+        NSLog(@"Error parsing dangerousSettings JSON: %@ %@", dangerousSettingsJson, error.localizedDescription);
+    } else {
+        BOOL autoSyncPurchases = dangerousSettingsDict[@"AutoSyncPurchases"];
+        dangerousSettings = [[RCDangerousSettings alloc] initWithAutoSyncPurchases:autoSyncPurchases];
+    }
 
     [RCPurchases configureWithAPIKey:apiKey
                            appUserID:appUserID
@@ -71,7 +86,7 @@ usesStoreKit2IfAvailable:(BOOL)usesStoreKit2IfAvailable
                       platformFlavor:self.platformFlavor
                platformFlavorVersion:self.platformFlavorVersion
             usesStoreKit2IfAvailable:usesStoreKit2IfAvailable
-                   dangerousSettings:nil];
+                   dangerousSettings:dangerousSettings];
 
     self.gameObject = gameObject;
     [[RCPurchases sharedPurchases] setDelegate:self];
@@ -399,13 +414,15 @@ void _RCSetupPurchases(const char *gameObject,
                        const char *appUserID,
                        const BOOL observerMode,
                        const BOOL usesStoreKit2IfAvailable,
-                       const char *userDefaultsSuiteName) {
+                       const char *userDefaultsSuiteName,
+                       const char *dangerousSettingsJson) {
     [_RCUnityHelperShared() setupPurchases:convertCString(apiKey)
                                  appUserID:convertCString(appUserID)
                                 gameObject:convertCString(gameObject)
                               observerMode:observerMode
                   usesStoreKit2IfAvailable:usesStoreKit2IfAvailable
-                     userDefaultsSuiteName:convertCString(userDefaultsSuiteName)];
+                     userDefaultsSuiteName:convertCString(userDefaultsSuiteName)
+                     dangerousSettingsJson:convertCString(dangerousSettingsJson)];
 }
 
 void _RCGetProducts(const char *productIdentifiersJSON, const char *type) {

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -7,12 +7,14 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
 {
     [DllImport("__Internal")]
     private static extern void _RCSetupPurchases(string gameObject, string apiKey, string appUserId, bool observerMode,
-                                                 bool usesStoreKit2IfAvailable, string userDefaultsSuiteName);
+                                                 bool usesStoreKit2IfAvailable, string userDefaultsSuiteName,
+                                                 string dangerousSettingsJson);
 
     public void Setup(string gameObject, string apiKey, string appUserId, bool observerMode, bool usesStoreKit2IfAvailable,
         string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson)
     {
-        _RCSetupPurchases(gameObject, apiKey, appUserId, observerMode, usesStoreKit2IfAvailable, userDefaultsSuiteName);
+        _RCSetupPurchases(gameObject, apiKey, appUserId, observerMode, usesStoreKit2IfAvailable,
+            userDefaultsSuiteName, dangerousSettingsJson);
     }
 
     [SuppressMessage("ReSharper", "NotAccessedField.Local")]


### PR DESCRIPTION
While working on #151 I noticed that `DangerousSettings` was not fully wired up in iOS. This fixes that so we can now pass dangerous settings to the native layer in iOS.