### PR TITLE
Makes hold job depend on tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,6 @@
 version: 2.1
 
 aliases:
-  release-tags-and-branches: &release-tags-and-branches
-    filters:
-      tags:
-        ignore: /^.*-SNAPSHOT/
-      branches:
-        only: /^release\/.*/
-
   release-tags: &release-tags
     filters:
       tags:
@@ -306,24 +299,6 @@ jobs:
 
 workflows:
   version: 2
-  build:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - export-package: *release-tags-and-branches
-      - build-test-android:
-          <<: *release-tags-and-branches
-          requires:
-            - export-package
-      - build-test-ios:
-          <<: *release-tags-and-branches
-          requires:
-            - export-package
-      - archive-ios:
-          <<: *release-tags-and-branches
-          requires:
-            - build-test-ios
   danger:
     when:
       not:
@@ -336,8 +311,24 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
+      - export-package: *release-branches
+      - build-test-android:
+          <<: *release-branches
+          requires:
+            - export-package
+      - build-test-ios:
+          <<: *release-branches
+          requires:
+            - export-package
+      - archive-ios:
+          <<: *release-branches
+          requires:
+            - build-test-ios
       - hold:
           type: approval
+          requires:
+            - build-test-android
+            - archive-ios
           <<: *release-branches
       - revenuecat/tag-current-branch:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,6 @@ workflows:
           requires:
             - hold
           <<: *release-branches
-      - export-package: *release-tags
       - github-release:
           <<: *release-tags
           requires:


### PR DESCRIPTION
Equivalent of https://github.com/RevenueCat/purchases-android/pull/644/files

Fixes two things:
- Makes sure integration tests pass before deploying anything
- Prevents integration tests from running also when the branch is tagged (after the hold job is approved), which was unnecessary