### PR TITLE
Fix github release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ workflows:
           <<: *release-branches
       - export-package:
           <<: *release-tags
-          name: 'post-release-export-package'
+          name: 'post-tag-export-package'
       - github-release:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ aliases:
         ignore: /^.*-SNAPSHOT/
       branches:
         ignore: /.*/
-  
+
   release-branches: &release-branches
     filters:
       tags:
@@ -334,6 +334,9 @@ workflows:
           requires:
             - hold
           <<: *release-branches
+      - export-package:
+          <<: *release-tags
+          name: 'post-release-export-package'
       - github-release:
           <<: *release-tags
           requires:


### PR DESCRIPTION
I noticed in #174 that the `github-release` job didn't start. Looking around I believe this is because this was removed in #170. 

I believe removing the dependency of `github-release` with `export-package` would also work, but it feels safer to have `github-release` depend on `export-package`. 

Since there are 2 `export-package` jobs now in the workflow (one to initiate the tests and another one needed to trigger the post approval job), circleci complained unless we differentiate them. This feels like a strange behavior on CircleCI side for this case...