### PR TITLE
Fix CircleCI deployment workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ workflows:
     jobs:
       - revenuecat/danger
 
-  deploy:
+  deploy-check:
     when:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
@@ -335,6 +335,17 @@ workflows:
             - hold
           <<: *release-branches
       - github-release: *release-tags
+
+  deploy:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - export-package: *release-tags
+      - github-release:
+          requires:
+            - export-package
+          <<: *release-tags
 
   snapshot-bump:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,6 @@ workflows:
           requires:
             - hold
           <<: *release-branches
-      - github-release: *release-tags
 
   deploy:
     when:


### PR DESCRIPTION
The deployment workflow stopped working after the changes in #170. A first attempt at fixing it was done in #177 but that caused an issue where the github-release job didn't find the required files in the workspace. Looks like since the branch of the workspace is different (one points to `release-branches` and the other `release-tags`) they are considered different workspaces so it can't share files between them. 

This PR restructures the deployment into 2 workflows. First `deploy-check` which runs deployment tests, initiates the approval job and creates the tag after approval. The second one builds `export-package` again and then performs the `github-release` job. That way, circleci should consider them part of the same workflow and allow them to share files between them.