### PR TITLE
added extra link to the correct file for symlinking sources

### DIFF
--- a/Subtester/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/mainTemplate.gradle
@@ -75,5 +75,5 @@ android {
 // that does exist here.
 // More info: https://forum.unity.com/threads/native-sources-inside-package-not-found-after-exporting-project-to-android.1355321/
 android.sourceSets.main.java.srcDirs += [
-    '**DIR_UNITYPROJECT**/../RevenueCat/Plugins/Android/PurchasesWrapper.java'
+    '**DIR_UNITYPROJECT**/../RevenueCat/Plugins/Android/'
 ]

--- a/Subtester/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/mainTemplate.gradle
@@ -68,6 +68,7 @@ android {
 // When using Unity Package Manager, this link will be wrong but still needed.
 **EXTERNAL_SOURCES**
 
+// IMPORTANT: If you're not installing through Unity Package Manager, remove the code below.
 // Symlink local sources. When using Unity's "Symlink local sources" checkbox,
 // The link will be wrong when using Unity Package Manager because of a bug in Unity.
 // That's not a problem if it points to a file that doesn't exist, but we need to add the path

--- a/Subtester/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/mainTemplate.gradle
@@ -64,4 +64,15 @@ android {
         ignoreAssetsPattern = "!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~"
     }**PACKAGING_OPTIONS**
 }**REPOSITORIES****SOURCE_BUILD_SETUP**
+
+// When using Unity Package Manager, this link will be wrong but still needed.
 **EXTERNAL_SOURCES**
+
+// Symlink local sources. When using Unity's "Symlink local sources" checkbox,
+// The link will be wrong when using Unity Package Manager because of a bug in Unity.
+// That's not a problem if it points to a file that doesn't exist, but we need to add the path
+// that does exist here.
+// More info: https://forum.unity.com/threads/native-sources-inside-package-not-found-after-exporting-project-to-android.1355321/
+android.sourceSets.main.java.srcDirs += [
+    '**DIR_UNITYPROJECT**/../RevenueCat/Plugins/Android/PurchasesWrapper.java'
+]


### PR DESCRIPTION
Starting the year off with a nice hack 😂 

When using "Symlink local sources" in Subtester, if the SDK is installed through Unity Package Manager, the wrong file is linked. 

This is due to a bug in Unity: https://forum.unity.com/threads/native-sources-inside-package-not-found-after-exporting-project-to-android.1355321/

This PR updates the build.gradle template so that we manually add the right source. The wrong source file will be added too, but that one doesn't really do anything since it points to an invalid path anyway. 