### PR TITLE
Fix for `NSInvalidArgumentException` in `GetPromotionalOffer`

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -265,14 +265,11 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     [RCCommonFunctionality promotionalOfferForProductIdentifier:productIdentifier
                                                       discount:discountIdentifier
                                                completionBlock:^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
-        NSMutableDictionary *response;
-        if (error) {
-            response = [NSMutableDictionary new];
-            response[@"error"] = error.info;
-
-        } else {
-            response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
+        NSDictionary *response = (error)
+        ? @{
+            @"error": error.info
         }
+        : responseDictionary;
         [self sendJSONObject:response toMethod:GET_PROMOTIONAL_OFFER];
     }];
 }

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -265,7 +265,15 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     [RCCommonFunctionality promotionalOfferForProductIdentifier:productIdentifier
                                                       discount:discountIdentifier
                                                completionBlock:^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
-        [self sendJSONObject:responseDictionary toMethod:GET_PROMOTIONAL_OFFER];
+        NSMutableDictionary *response;
+        if (error) {
+            response = [NSMutableDictionary new];
+            response[@"error"] = error.info;
+
+        } else {
+            response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
+        }
+        [self sendJSONObject:response toMethod:GET_PROMOTIONAL_OFFER];
     }];
 }
 

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -263,13 +263,18 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 - (void)promotionalOfferForProductIdentifier:(NSString *)productIdentifier
                                     discount:(NSString *)discountIdentifier {
     [RCCommonFunctionality promotionalOfferForProductIdentifier:productIdentifier
-                                                      discount:discountIdentifier
-                                               completionBlock:^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
+                                                       discount:discountIdentifier
+                                                completionBlock:^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
         NSDictionary *response = (error)
         ? @{
             @"error": error.info
         }
         : responseDictionary;
+
+        if (response == nil) {
+            response = @{};
+        }
+
         [self sendJSONObject:response toMethod:GET_PROMOTIONAL_OFFER];
     }];
 }

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -265,15 +265,18 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     [RCCommonFunctionality promotionalOfferForProductIdentifier:productIdentifier
                                                        discount:discountIdentifier
                                                 completionBlock:^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
+        if (error == nil && responseDictionary == nil) {
+            NSError *nsError = [[NSError alloc] initWithDomain:RCPurchasesErrorCodeDomain
+                                                          code:RCUnknownError
+                                                      userInfo:@{NSLocalizedDescriptionKey: @"Both error and response are null"}];
+            error = [[RCErrorContainer alloc] initWithError:nsError extraPayload:@{}];
+        }
+
         NSDictionary *response = (error)
         ? @{
             @"error": error.info
         }
         : responseDictionary;
-
-        if (response == nil) {
-            response = @{};
-        }
 
         [self sendJSONObject:response toMethod:GET_PROMOTIONAL_OFFER];
     }];


### PR DESCRIPTION
We were not handling errors in `GetPromotionalOffer` and we were trying to send a nil response to the Unity message layer

[TRIAGE-276]

[TRIAGE-276]: https://revenuecats.atlassian.net/browse/TRIAGE-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ