### PR TITLE
Runs integration tests on main too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,15 @@ aliases:
       branches:
         only: /^release\/.*/
 
+  release-branches-and-main: &release-branches-and-main
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only:
+          - /^release\/.*/
+          - main
+
   only-main-branch: &only-main-branch
     filters:
       tags:
@@ -380,11 +389,11 @@ workflows:
       - build-subtester-android: *release-branches
       - build-subtester-ios: *release-branches
       - build-integration-tests-android:
-          <<: *release-branches
+          <<: *release-branches-and-main
           requires:
             - export-package
       - build-integration-tests-ios:
-          <<: *release-branches
+          <<: *release-branches-and-main
           requires:
             - export-package
       - archive-ios:


### PR DESCRIPTION
This https://github.com/RevenueCat/purchases-unity/pull/237 broke integration tests

Running these on every PR would be expensive and would slow down merging too much, since they are slow, but running them on main would help determine which PR  broke them if they break