### PR TITLE
Update fastlane-plugin-revenuecat version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 738f255ee8c6d4dbbb9ebdda79782ed90529e00a
+  revision: 3b03efa56b3551d01b04bb13cfa9758309374672
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,12 +10,21 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-files_with_version_number = [
-  './.version',
-  './RevenueCat/Plugins/iOS/PurchasesUnityHelper.m',
-  './RevenueCat/Plugins/Android/PurchasesWrapper.java',
-  './RevenueCat/package.json'
-]
+files_with_version_number = {
+    './.version' => ['{x]'],
+    './RevenueCat/Plugins/iOS/PurchasesUnityHelper.m' => ['return @"{x}"'],
+    './RevenueCat/Plugins/Android/PurchasesWrapper.java' => ['PLUGIN_VERSION = "{x}"'],
+    './RevenueCat/package.json' => ['"version": "{x}"']
+}
+ANDROID_PHC_DEPENDENCY_PATTERN = 'com.revenuecat.purchases:purchases-hybrid-common:[{x}]'
+files_to_update_phc_version = {
+    'RevenueCat/Plugins/Editor/RevenueCatDependencies.xml' => [
+        ANDROID_PHC_DEPENDENCY_PATTERN,
+        'name="PurchasesHybridCommon" version="{x}"'
+    ],
+    'Subtester/Assets/Plugins/Android/mainTemplate.gradle' => [ANDROID_PHC_DEPENDENCY_PATTERN],
+    'Subtester/ProjectSettings/AndroidResolverDependencies.xml' => [ANDROID_PHC_DEPENDENCY_PATTERN],
+}
 repo_name = 'purchases-unity'
 changelog_latest_path = './CHANGELOG.latest.md'
 changelog_path = './CHANGELOG.md'
@@ -99,11 +108,6 @@ lane :update_hybrid_common do |options|
 
   UI.message("ℹ️  Current Purchases Hybrid Common version: #{current_phc_version}")
   UI.message("ℹ️  Setting Purchases Hybrid Common version: #{new_version_number}")
-  files_to_update = [
-    'RevenueCat/Plugins/Editor/RevenueCatDependencies.xml',
-    'Subtester/Assets/Plugins/Android/mainTemplate.gradle',
-    'Subtester/ProjectSettings/AndroidResolverDependencies.xml'
-  ]
 
   if dry_run
     UI.message("ℹ️  Nothing more to do, dry_run: true")
@@ -112,7 +116,7 @@ lane :update_hybrid_common do |options|
 
   bump_phc_version(
     repo_name: repo_name,
-    files_to_update: files_to_update,
+    files_to_update: files_to_update_phc_version,
     current_version: current_phc_version,
     next_version: new_version_number,
     open_pr: options[:open_pr] || false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,7 @@
 #
 
 files_with_version_number = {
-    './.version' => ['{x]'],
+    './.version' => ['{x}'],
     './RevenueCat/Plugins/iOS/PurchasesUnityHelper.m' => ['return @"{x}"'],
     './RevenueCat/Plugins/Android/PurchasesWrapper.java' => ['PLUGIN_VERSION = "{x}"'],
     './RevenueCat/package.json' => ['"version": "{x}"']


### PR DESCRIPTION
Updated plugin to use the changes from https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/46

This changes prevent updating the wrong version number when bumping either the version of the SDK or purchases-hybrid-common's version.