### PR TITLE
[BC5] Map SubscriptionOption.PricingPhases

### DIFF
--- a/RevenueCat/Scripts/SubscriptionOption.cs
+++ b/RevenueCat/Scripts/SubscriptionOption.cs
@@ -93,6 +93,18 @@ public partial class Purchases
             IsBasePlan = response["isBasePlan"];
             BillingPeriod = new Period(response["billingPeriod"]);
             IsPrepaid = response["isPrepaid"];
+
+            var pricingPhasesNode = response["pricingPhases"];
+            var pricingPhasesTemporaryList = new List<PricingPhase>(); 
+            if (pricingPhasesNode != null && !pricingPhasesNode.IsNull) {
+                foreach (var phase in pricingPhasesNode)
+                {
+                    pricingPhasesTemporaryList.Add(new PricingPhase(phase));
+                }
+                PricingPhases = pricingPhasesTemporaryList.ToArray();
+            }
+
+
             var fullPricePhaseNode = response["fullPricePhase"];
             if (fullPricePhaseNode != null && !fullPricePhaseNode.IsNull)
             {

--- a/Subtester/Assets/Scripts/PurchasesListener.cs
+++ b/Subtester/Assets/Scripts/PurchasesListener.cs
@@ -92,8 +92,9 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                             } else {
                                 parts.Add("ITS SO NULL");
                             }
+                            // var info = subscriptionOption.ProductId + " " + subscriptionOption.ID;
                             var info = String.Join(" -> ", parts.ToArray());
-                            CreateButton(info,  () => PurchaseSubscriptionOptionButtonClicked(package.StoreProduct.DefaultOption));
+                            CreateButton(info,  () => PurchaseSubscriptionOptionButtonClicked(subscriptionOption));
                         }
                     }
                 }

--- a/Subtester/Assets/Scripts/PurchasesListener.cs
+++ b/Subtester/Assets/Scripts/PurchasesListener.cs
@@ -72,7 +72,30 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                     if (package == null) continue;
                     var label = package.PackageType + " " + package.StoreProduct.PriceString;
                     CreateButton("Buy as Package: " + label, () => PurchasePackageButtonClicked(package));
-                    CreateButton("Buy as SubsOpt: " + label, () => PurchaseSubscriptionOptionButtonClicked(package));
+
+                    // CreateButton("Buy as SubsOpt: " + label,  () => PurchaseSubscriptionOptionButtonClicked(package));
+                    var options = package.StoreProduct.SubscriptionOptions;
+                    if (options is not null) {
+                        foreach (var subscriptionOption in options) {
+                            List<string> parts = new List<string>();
+                            var label2 = package.PackageType;
+
+                            var phases = subscriptionOption.PricingPhases;
+                            if (phases is not null) {
+                                foreach (var pricingPhase in phases) {
+                                    var period = pricingPhase.BillingPeriod;
+                                    var price = pricingPhase.Price;
+                                    if (period is not null && price is not null) {
+                                        parts.Add(price.Formatted + " for " + period.ISO8601);
+                                    }
+                                }
+                            } else {
+                                parts.Add("ITS SO NULL");
+                            }
+                            var info = String.Join(" -> ", parts.ToArray());
+                            CreateButton(info,  () => PurchaseSubscriptionOptionButtonClicked(package.StoreProduct.DefaultOption));
+                        }
+                    }
                 }
             }
         });
@@ -152,10 +175,10 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
         });
     }
     
-    private void PurchaseSubscriptionOptionButtonClicked(Purchases.Package package)
+    private void PurchaseSubscriptionOptionButtonClicked(Purchases.SubscriptionOption subscriptionOption)
     {
         var purchases = GetComponent<Purchases>();
-        purchases.PurchaseSubscriptionOption(package.StoreProduct.DefaultOption, (productIdentifier, customerInfo, userCancelled, error) =>
+        purchases.PurchaseSubscriptionOption(subscriptionOption, (productIdentifier, customerInfo, userCancelled, error) =>
         {
             if (!userCancelled)
             {


### PR DESCRIPTION
## Motivation

- View all subscription options for a product
- View all pricing phases for a subscription option

## Description

### Purchase Tester
- Added buttons for each subscription option for a product

### SDK
- Added a mapping to `PricingPhases` in `SubscriptionOption`

![Screenshot 2023-08-01 at 12 25 37 PM](https://github.com/RevenueCat/purchases-unity/assets/401294/fe5572ed-0bd4-4c36-bd5b-991623d8c802)
