### PR TITLE
Fix for iOS discounts not being returned

### DIFF
--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -62,31 +62,36 @@ public partial class Purchases
             {
                 DefaultOption = new SubscriptionOption(defaultOptionJsonNode);
             }
+
             var subscriptionOptionsResponse = response["subscriptionOptions"];
-            if (subscriptionOptionsResponse == null)
+            if (subscriptionOptionsResponse == null) 
             {
                 SubscriptionOptions = null;
-                return;
             }
-            var subscriptionOptionsTemporaryList = new List<SubscriptionOption>();
-            foreach (var subscriptionOptionResponse in subscriptionOptionsResponse)
+            else
             {
-                subscriptionOptionsTemporaryList.Add(new SubscriptionOption(subscriptionOptionResponse));
+                var subscriptionOptionsTemporaryList = new List<SubscriptionOption>();
+                foreach (var subscriptionOptionResponse in subscriptionOptionsResponse)
+                {
+                    subscriptionOptionsTemporaryList.Add(new SubscriptionOption(subscriptionOptionResponse));
+                }
+                SubscriptionOptions = subscriptionOptionsTemporaryList.ToArray();
             }
-            SubscriptionOptions = subscriptionOptionsTemporaryList.ToArray();
 
             var discountsResponse = response["discounts"];
             if (discountsResponse == null)
             {
                 Discounts = null;
-                return;
             }
-            var temporaryList = new List<Discount>();
-            foreach (var discountResponse in discountsResponse)
+            else
             {
-                temporaryList.Add(new Discount(discountResponse));
+                var temporaryList = new List<Discount>();
+                foreach (var discountResponse in discountsResponse)
+                {
+                    temporaryList.Add(new Discount(discountResponse));
+                }
+                Discounts = temporaryList.ToArray();
             }
-            Discounts = temporaryList.ToArray();
         }
 
         public override string ToString()

--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -64,7 +64,7 @@ public partial class Purchases
             }
 
             var subscriptionOptionsResponse = response["subscriptionOptions"];
-            if (subscriptionOptionsResponse == null) 
+            if (subscriptionOptionsResponse == null)
             {
                 SubscriptionOptions = null;
             }


### PR DESCRIPTION
## Motivation

[DENG-534](https://linear.app/revenuecat/issue/DENG-534/unity-sdk-ios-discounts-arent-returned)

iOS discounts were not being returned

## Description

Logic for Google Play subscription options had an early return if they weren't found which lead to the skipping of iOS discount logic

- Removed an early return in subscription option logic
  - Replaced with an else to set the subscription options
- Removed an early return in discount logic
  - Replaced with an else to set the discounts
