### PR TITLE
Remove creation of special UnityIAP package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,12 +187,9 @@ jobs:
           root: .
           paths:
             - Purchases.unitypackage
-            - Purchases-UnityIAP.unitypackage
 
       - store_artifacts:
           path: Purchases.unitypackage
-      - store_artifacts:
-          path: Purchases-UnityIAP.unitypackage
 
   build-subtester-android:
     executor: unity-android

--- a/AMAZON-INSTRUCTIONS.md
+++ b/AMAZON-INSTRUCTIONS.md
@@ -1,10 +1,10 @@
 ## Instructions
-- Download the `Purchases.unitypackage` (`Purchases-UnityIAP.unitypackage` if using in observer mode) in the release.
+- Download the `Purchases.unitypackage` in the release.
 - Open your Unity Project
 - Select Import package -> Custom package
 <img width="471" alt="Screen Shot 2021-11-24 at 3 55 50 PM" src="https://user-images.githubusercontent.com/664544/143326927-764cb381-30a7-4d8d-8f3a-3c45c1e9d67f.png">
 
-- Select Purchases.unitypackage (or `Purchases-UnityIAP.unitypackage`) and make sure all of the files are selected and press import
+- Select Purchases.unitypackage and make sure all of the files are selected and press import
 
 <img width="472" alt="Screen Shot 2021-11-24 at 3 56 10 PM" src="https://user-images.githubusercontent.com/664544/143326950-ec8d5993-cd9e-468a-9a9a-27fee8a63519.png">
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ lane :github_release do |options|
     repo_name: repo_name,
     github_api_token: ENV["GITHUB_TOKEN"],
     changelog_latest_path: changelog_latest_path,
-    upload_assets: ['Purchases.unitypackage', 'Purchases-UnityIAP.unitypackage']
+    upload_assets: ['Purchases.unitypackage']
   )
 end
 

--- a/scripts/create-unity-package.sh
+++ b/scripts/create-unity-package.sh
@@ -9,7 +9,6 @@ done
 
 PROJECT="$PWD/Subtester"
 PACKAGE="$PWD/Purchases.unitypackage"
-PACKAGE_UNITY_IAP="$PWD/Purchases-UnityIAP.unitypackage"
 
 # Subtester uses the purchases-unity SDK as a package, but we use it to export a .unitypackage.
 # Unity won't export files from package dependencies so we need to add the SDK files inside the Subtester/Assets folder,
@@ -79,31 +78,6 @@ else
     -exportPackage $FOLDERS_TO_EXPORT $PACKAGE
 fi
 
-echo "Unity package created. Updating dependency for Unity IAP compatibility"
-
-export REGULAR_PACKAGE_NAME="com.revenuecat.purchases:purchases-hybrid-common:"
-export UNITY_IAP_PACKAGE_NAME="com.revenuecat.purchases:purchases-hybrid-common-unityiap:"
-
-sed -i -e "s/spec=\"$REGULAR_PACKAGE_NAME/spec=\"$UNITY_IAP_PACKAGE_NAME/" \
-./RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
-
-echo "📦 Creating Purchases-UnityIAP.unitypackage, this may take a minute."
-
-if [ ! -z "$CI" ] ; then
-    xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' $UNITY_BIN -gvh_disable \
-    -nographics \
-    -silent-crashes \
-    -projectPath $PROJECT \
-    -force-free -quit -batchmode -logFile \
-    -importPackage $PROJECT/external-dependency-manager-latest.unitypackage \
-    -exportPackage $FOLDERS_TO_EXPORT $PACKAGE_UNITY_IAP
-else
-    $UNITY_BIN -gvh_disable \
-    -nographics \
-    -projectPath $PROJECT \
-    -force-free -quit -batchmode -logFile exportlog.txt \
-    -importPackage $PROJECT/external-dependency-manager-latest.unitypackage \
-    -exportPackage $FOLDERS_TO_EXPORT $PACKAGE_UNITY_IAP
-fi
+echo "Unity package created"
 
 rm $SYMBOLIC_LINK_PATH


### PR DESCRIPTION
Removed the creation of the UnityIAP package, because it was pointing to a dependency in Maven that doesn't exist anymore