### PR TITLE
`CI`: disable `prepare-next-version`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,20 +321,6 @@ jobs:
           working_directory: IntegrationTests/buildiOS
           command: bundle exec fastlane archive workspace:"buildiOS/Unity-iPhone.xcworkspace"
 
-  prepare-next-version:
-    description: "Creates a PR with the new snapshot version"
-    docker:
-      - image: cimg/ruby:3.1.2
-    steps:
-      - checkout
-      - revenuecat/install-gem-unix-dependencies:
-          cache-version: v1
-      - revenuecat/trust-github-key
-      - revenuecat/setup-git-credentials
-      - run:
-          name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
-
   github-release:
     description: "Creates a github release"
     docker:
@@ -418,14 +404,6 @@ workflows:
           requires:
             - export-package
           <<: *release-tags
-
-  snapshot-bump:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - prepare-next-version:
-          <<: *only-main-branch
 
   weekly-run-workflow:
     when:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,16 +83,6 @@ lane :github_release do |options|
   )
 end
 
-desc "Creates PR changing version to next minor adding a -SNAPSHOT suffix"
-lane :prepare_next_version do |options|
-  create_next_snapshot_version(
-    current_version: current_version_number,
-    repo_name: repo_name,
-    github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
-    files_to_update: files_with_version_number
-  )
-end
-
 desc "Update hybrid common pod and gradle and pushes changes to a new branch if open_pr option is true"
 lane :update_hybrid_common do |options|
   if options[:dry_run]


### PR DESCRIPTION
As discussed, these provide little value in the hybrids and instead create unnecessary busy work.
