### PR TITLE
Fix `isAnonymous` in iOS

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -573,8 +573,8 @@ void _RCEnableAdServicesAttributionTokenCollection() {
     [_RCUnityHelperShared() enableAdServicesAttributionTokenCollection];
 }
 
-void _RCIsAnonymous() {
-    [_RCUnityHelperShared() isAnonymous];
+BOOL _RCIsAnonymous() {
+    return [_RCUnityHelperShared() isAnonymous];
 }
 
 void _RCCheckTrialOrIntroductoryPriceEligibility(const char *productIdentifiersJSON) {


### PR DESCRIPTION
We were not returning anything in iOS for `isAnonymous`, which was evaluating to `true`.

https://linear.app/revenuecat/issue/SDK-3285/fix-isanonymous-in-ios-unity