### PR TITLE
Fix `setMixpanelDistinctID` setter

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -354,7 +354,7 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 }
 
 - (void)setMixpanelDistinctID:(nullable NSString *)mixpanelDistinctID {
-    [RCCommonFunctionality setAirshipChannelID:mixpanelDistinctID];
+    [RCCommonFunctionality setMixpanelDistinctID:mixpanelDistinctID];
 }
 
 - (void)setFirebaseAppInstanceID:(nullable NSString *)firebaseAppInstanceID {


### PR DESCRIPTION
Fixes #418. We were incorrectly setting the mixpanel ID. This fixes that issues for now. We will try to improve our infrastructure to have some kind of test coverage for these.
