### PR TITLE
Make `CustomerInfo` `allPurchaseDates` values nullable

### DIFF
--- a/IntegrationTests/Assets/APITests/CustomerInfoAPITests.cs
+++ b/IntegrationTests/Assets/APITests/CustomerInfoAPITests.cs
@@ -18,7 +18,7 @@ namespace DefaultNamespace
             DateTime requestDate = customerInfo.RequestDate;
             DateTime? originalPurchaseDate = customerInfo.OriginalPurchaseDate;
             Dictionary<string, DateTime?> allExpirationDates = customerInfo.AllExpirationDates;
-            Dictionary<string, DateTime> allPurchaseDates = customerInfo.AllPurchaseDates;
+            Dictionary<string, DateTime?> allPurchaseDates = customerInfo.AllPurchaseDates;
             string originalApplicationVersion = customerInfo.OriginalApplicationVersion;
             string managementURL = customerInfo.ManagementURL;
             List<Purchases.StoreTransaction> nonSubscriptionTransactions = customerInfo.NonSubscriptionTransactions;

--- a/RevenueCat/Scripts/CustomerInfo.cs
+++ b/RevenueCat/Scripts/CustomerInfo.cs
@@ -30,7 +30,7 @@ public partial class Purchases
         public DateTime RequestDate;
         public DateTime? OriginalPurchaseDate;
         public Dictionary<string, DateTime?> AllExpirationDates;
-        public Dictionary<string, DateTime> AllPurchaseDates;
+        public Dictionary<string, DateTime?> AllPurchaseDates;
         [CanBeNull] public string OriginalApplicationVersion;
         [CanBeNull] public string ManagementURL;
         public List<StoreTransaction> NonSubscriptionTransactions;
@@ -73,10 +73,19 @@ public partial class Purchases
                 }
             }
 
-            AllPurchaseDates = new Dictionary<string, DateTime>();
+            AllPurchaseDates = new Dictionary<string, DateTime?>();
             foreach (var keyValue in response["allPurchaseDatesMillis"])
             {
-                AllPurchaseDates.Add(keyValue.Key, FromUnixTimeInMilliseconds(keyValue.Value.AsLong));
+                var productID = keyValue.Key;
+                var purchaseDateJSON = keyValue.Value;
+                if (purchaseDateJSON != null && !purchaseDateJSON.IsNull && purchaseDateJSON.AsLong != 0L)
+                {
+                    AllPurchaseDates.Add(productID, FromUnixTimeInMilliseconds(purchaseDateJSON.AsLong));
+                }
+                else
+                {
+                    AllPurchaseDates.Add(productID, null);
+                }
             }
 
             OriginalApplicationVersion = response["originalApplicationVersion"];


### PR DESCRIPTION
This property can have nullable values in the native SDKs, but it was not nullable in purchases-unity. This supports it being nullable. 

If you use the `AllPurchaseDates` property from `CustomerInfo`, you will need to handle nullable values with this change.