### PR TITLE
Fix `purchasePackage` when no targeting context

### DIFF
--- a/RevenueCat/Scripts/PresentedOfferingContext.cs
+++ b/RevenueCat/Scripts/PresentedOfferingContext.cs
@@ -17,7 +17,11 @@ public partial class Purchases
         {
             OfferingIdentifier = response["offeringIdentifier"];
             PlacementIdentifier = response["placementIdentifier"];
-            TargetingContext = new PresentedOfferingTargetingContext(response["targetingContext"]);
+
+            var targetingContextNode = response["targetingContext"];
+            if (targetingContextNode != null && !targetingContextNode.IsNull) {
+                TargetingContext = new PresentedOfferingTargetingContext(targetingContextNode);
+            }
         }
 
         public override string ToString()


### PR DESCRIPTION
## Motivation

Fixes issue when calling `purchasePackage` without a targeting context

## Description

Only create targeting context object if not null
