### PR TITLE
API improvements

### DIFF
--- a/RevenueCat/Scripts/UpdatedCustomerInfoListener.cs
+++ b/RevenueCat/Scripts/UpdatedCustomerInfoListener.cs
@@ -2,8 +2,8 @@ using UnityEngine;
 
 public partial class Purchases
 {
-    public abstract class UpdatedCustomerInfoListener : MonoBehaviour
+    public interface IUpdatedCustomerInfoListener
     {
-        public abstract void CustomerInfoReceived(CustomerInfo customerInfo);
+        public void CustomerInfoReceived(CustomerInfo customerInfo);
     }
 }

--- a/RevenueCat/Scripts/UpdatedCustomerInfoListener.cs
+++ b/RevenueCat/Scripts/UpdatedCustomerInfoListener.cs
@@ -6,4 +6,9 @@ public partial class Purchases
     {
         public void CustomerInfoReceived(CustomerInfo customerInfo);
     }
+    
+    public abstract class UpdatedCustomerInfoListener : MonoBehaviour, IUpdatedCustomerInfoListener
+    {
+        public abstract void CustomerInfoReceived(CustomerInfo customerInfo);
+    }
 }


### PR DESCRIPTION
- [x] A description about what and why you are contributing, even if it's trivial.

This PR addresses two API issues:
1. Purchases Listener is currently an abstract `MonoBehaviour`, which ties the behaviour to Unity components. This is not bad, but it does limit you, which is entirely not needed, if you mostly use the API from code. There's no other requirement that this should in fact be an abstract class. So a new interface is introduced instead and backwards support is added, so that the `UpdatedCustomerInfoListener` implements the interface.

2. The whole `Purchases` object which is required for RevenueCat to operate initializes itself fairly late in `Start` function. This is a problem, if you need to do anything beforehand as we're booting our game up in `Awake` method. The script order is usually undefined and we've seen many differences in it between real devices and Editor, so sometimes `Purchases` would prepare itself for API type of configuration, sometimes we would be too early calling `Configure` and crash with `NullPointerException` on internal `_wrapper`. To get around this problem, we extracted initialization of wrapper to a separate function that only creates the instances once, but can be called many times. That way `Configure` will `Prepare` the wrapper, before it calls to it's `Setup` method.

- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
 No open issues right now for these improvements.

- [x] If applicable, unit tests.
No additional Unit Tests required.