### PR TITLE
Update Deferred proration mode value to match BC7

### DIFF
--- a/RevenueCat/Scripts/ProrationMode.cs
+++ b/RevenueCat/Scripts/ProrationMode.cs
@@ -19,7 +19,7 @@ public partial class Purchases
 
         /// Replacement takes effect when the old plan expires, and the new price will
         /// be charged at the same time.
-        Deferred = 4,
+        Deferred = 6,
 
         /// Replacement takes effect immediately, and the user is charged full price
         /// of new plan and is given a full billing cycle of subscription,


### PR DESCRIPTION
With the BC7 update done in #485, we also had to update the Deferred mode underlying int value to match the new value expected by the billing client. This shouldn't have affected users since the previous change wasn't shipped yet