### PR TITLE
Add SyncPurchases method overload that accepts a callback as parameter

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -169,6 +169,11 @@ public class PurchasesAPITests : MonoBehaviour
         });
 
         purchases.SyncPurchases();
+        purchases.SyncPurchases((customerInfo, error) =>
+        {
+            receivedCustomerInfo = customerInfo;
+            receivedError = error;
+        });
         purchases.EnableAdServicesAttributionTokenCollection();
         Dictionary<string, Purchases.IntroEligibility> receivedEligibilities;
         purchases.CheckTrialOrIntroductoryPriceEligibility(new string[] { "a", "b" },

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -47,6 +47,7 @@ public class PurchasesWrapper {
     private static final String CAN_MAKE_PAYMENTS = "_canMakePayments";
     private static final String GET_PROMOTIONAL_OFFER = "_getPromotionalOffer";
     private static final String GET_LWA_CONSENT_STATUS = "_getAmazonLWAConsentStatus";
+    private static final String SYNC_PURCHASES = "_syncPurchases";
 
     private static final String HANDLE_LOG = "_handleLog";
 
@@ -378,7 +379,7 @@ public class PurchasesWrapper {
     }
 
     public static void syncPurchases() {
-        CommonKt.syncPurchases();
+        CommonKt.syncPurchases(getCustomerInfoListener(SYNC_PURCHASES));
     }
 
     public static boolean isAnonymous() {

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -25,6 +25,7 @@ static NSString *const CAN_MAKE_PAYMENTS = @"_canMakePayments";
 static NSString *const GET_PROMOTIONAL_OFFER = @"_getPromotionalOffer";
 static NSString *const HANDLE_LOG = @"_handleLog";
 static NSString *const RECORD_PURCHASE = @"_recordPurchase";
+static NSString *const SYNC_PURCHASES = @"_syncPurchases";
 
 #pragma mark Utility Methods
 
@@ -158,9 +159,7 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     // on Android, syncPurchases doesn't have a completion block. So instead of
     // calling getCustomerInfoCompletionBlockFor:SYNC_PURCHASES, we just
     // print the response, to match Android behavior.
-    [RCCommonFunctionality syncPurchasesWithCompletionBlock:^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
-        NSLog(@"received syncPurchases response: \n customerInfo: %@ \n error:%@", responseDictionary, error);
-    }];
+    [RCCommonFunctionality syncPurchasesWithCompletionBlock:[self getCustomerInfoCompletionBlockFor:SYNC_PURCHASES]];
 }
 
 - (void)logInWithAppUserID:(NSString *)appUserID {

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -695,6 +695,36 @@ public partial class Purchases : MonoBehaviour
         _wrapper.SyncPurchases();
     }
 
+    private CustomerInfoFunc SyncPurchasesCallback { get; set; }
+
+    /// <summary>
+    /// This method will post all purchases associated with the current App Store account to RevenueCat and
+    /// become associated with the current <c>appUserID</c>.
+    /// </summary>
+    ///
+    /// If the receipt is being used by an existing user, the current <c>appUserID</c> will be aliased together with
+    /// the <c>appUserID</c> of the existing user.
+    /// Going forward, either <c>appUserID</c> will be able to reference the same user.
+    ///
+    /// <remarks>
+    /// Warning: This function should only be called if you're not calling any purchase method.
+    /// </remarks>
+    ///
+    /// <remarks>
+    /// Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
+    /// on the device does not contain subscriptions, but the user has made subscription purchases, this method
+    /// won't be able to restore them. Use <see cref="RestorePurchases"/> to cover those cases.
+    /// </remarks>
+    /// <seealso href="https://docs.revenuecat.com/docs/restoring-purchases"/>
+    ///
+    /// <param name="callback"> A <see cref="CustomerInfoFunc"/> which will contain a <see cref="CustomerInfo"/>
+    /// if sync was successful, or an error otherwise. </param>
+    public void SyncPurchases(CustomerInfoFunc callback)
+    {
+        SyncPurchasesCallback = callback;
+        _wrapper.SyncPurchases();
+    }
+
     /// <summary>
     /// Android only. Noop in iOS.
     ///
@@ -1315,6 +1345,13 @@ public partial class Purchases : MonoBehaviour
         Debug.Log("_restorePurchases " + customerInfoJson);
         ReceiveCustomerInfoMethod(customerInfoJson, RestorePurchasesCallback);
         RestorePurchasesCallback = null;
+    }
+
+    private void _syncPurchases(string customerInfoJson)
+    {
+        Debug.Log("_syncPurchases " + customerInfoJson);
+        ReceiveCustomerInfoMethod(customerInfoJson, SyncPurchasesCallback);
+        SyncPurchasesCallback = null;
     }
 
     // ReSharper disable once UnusedMember.Local

--- a/Subtester/Assets/Scripts/PurchasesListener.cs
+++ b/Subtester/Assets/Scripts/PurchasesListener.cs
@@ -391,8 +391,17 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
     void SyncPurchases()
     {
         var purchases = GetComponent<Purchases>();
-        purchases.SyncPurchases();
-        infoLabel.text = "Purchases sync started. Note: there's no callback for this method in Unity";
+        purchases.SyncPurchases((customerInfo, error) =>
+        {
+            if (error != null)
+            {
+                LogError(error);
+            }
+            else
+            {
+                DisplayCustomerInfo(customerInfo);
+            }
+        });
     }
 
     void CanMakePayments()


### PR DESCRIPTION
Historically, `SyncPurchases` didn't return a callback in Android (it did on iOS) so for hybrids we were forced to not accept a callback.

This is problematic because you can't know for sure when the `SyncPurchases` request finished, in order to for example call `getCustomerInfo` to get updated entitlements.

We recently [updated PHC](https://github.com/RevenueCat/purchases-hybrid-common/pull/875) adding a version of the `SyncPurchases` method that accepts a callback, and this PR brings this improvement to Unity.

In order to keep backwards compatibility, and since C# accepts method overloads, we're simply adding a new `SyncPurchases` method that accepts a callback.

In the future we cal release a new minor that deprecates the old `SyncPurchases` method without callback.