### PR TITLE
Update allowSharingAppStoreAccount Deprecation Message

### DIFF
--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -511,7 +511,9 @@ public partial class Purchases : MonoBehaviour
     }
 
     // ReSharper disable once UnusedMember.Global
-    [Obsolete("Deprecated, configure behavior through the RevenueCat Dashboard instead.")]
+    [Obsolete(@"Configure behavior through the RevenueCat dashboard instead. 
+    If you have configured the 'Legacy' restore behavior in the RevenueCat Dashboard
+    and are currently setting this to true, keep this setting active.")]
     public void SetAllowSharingStoreAccount(bool allow)
     {
         _wrapper.SetAllowSharingStoreAccount(allow);


### PR DESCRIPTION
### Description
Updates the deprecation message of `allowSharingAppStoreAccount` to tell people who are already using the field to continue using it and not remove it.