### PR TITLE
Adds docs to `StoreProduct`

### DIFF
--- a/RevenueCat/Scripts/Offering.cs
+++ b/RevenueCat/Scripts/Offering.cs
@@ -80,7 +80,7 @@ public partial class Purchases
         {
             return $"{nameof(Identifier)}: {Identifier}\n" +
                    $"{nameof(ServerDescription)}: {ServerDescription}\n" +
-                   $"{nameof(AvailablePackages)}: {AvailablePackages}\n" +
+                   $"{nameof(AvailablePackages)}: {string.Join(", ", AvailablePackages)}\n" +
                    $"{nameof(Metadata)}: {DictToString(Metadata)}\n" +
                    $"{nameof(Lifetime)}: {Lifetime}\n" +
                    $"{nameof(Annual)}: {Annual}\n" +

--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -10,23 +10,83 @@ public partial class Purchases
     /// </summary>
     public class StoreProduct
     {
+        /// <summary>
+        /// Title of the product.
+        /// </summary>
+        /// <returns></returns>
         public readonly string Title;
+
+        /// <summary>
+        /// Product Id.
+        /// </summary>
+        /// <returns></returns>
         public readonly string Identifier;
+
+        /// <summary>
+        /// Description of the product.
+        /// </summary>
+        /// <returns></returns> 
         public readonly string Description;
+
+        /// <summary>
+        /// Price of the product in the local currency.
+        /// Contains the price value of DefaultOption for Google Play.
+        /// </summary>
+        /// <returns></returns>
         public readonly float Price;
+
+        /// <summary>
+        /// Formatted price of the item, including its currency sign.
+        /// Contains the formatted price value of DefaultOption for Google Play.
+        /// </summary>
+        /// <returns></returns>
         public readonly string PriceString;
+
+        /// <summary>
+        /// Currency code for price and original price.
+        /// Contains the currency code of DefaultOption for Google Play.
+        /// </summary>
+        /// <returns></returns>
         [CanBeNull] public readonly string CurrencyCode;
+        
+        /// <summary>
+        /// Introductory price of the product. Null if no introductory price is available.
+        /// It contains the free trial if available and user is eligible for it.
+        /// Otherwise, it contains the introductory price of the product if the user is eligible for it.
+        /// This will be null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
         public IntroductoryPrice IntroductoryPrice;
+
+        /// <summary>
+        /// Product category of the product.
+        /// </summary>
+        /// <returns></returns>
         [CanBeNull] public readonly ProductCategory ProductCategory;
+
+        /// <summary>
+        /// Default subscription option for a product. Google Play only.
+        /// </summary>
+        /// <returns></returns>
         [CanBeNull] public readonly SubscriptionOption DefaultOption;
+
+        /// <summary>
+        /// Collection of subscription options for a product. Google Play only.
+        /// </summary>
+        /// <returns></returns>
         [CanBeNull] public readonly SubscriptionOption[] SubscriptionOptions;
+
+        /// <summary>
+        /// Offering context this package belongs to.
+        /// Null if not using offerings or if fetched directly from store via GetProducts.
+        /// </summary>
         [CanBeNull] public readonly PresentedOfferingContext PresentedOfferingContext;
 
         [Obsolete("Deprecated, use PresentedOfferingContext instead.", false)]
         [CanBeNull] public readonly string PresentedOfferingIdentifier;
 
         /// <summary>
-        /// Collection of iOS promotional offers for a product. Null for Android.
+        /// Collection of iOS promotional offers for a product. Null for Android and Amazon.
         /// </summary>
         /// <returns></returns>
         [CanBeNull] public readonly Discount[] Discounts;

--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -171,11 +171,12 @@ public partial class Purchases
                    $"{nameof(Price)}: {Price}\n" +
                    $"{nameof(PriceString)}: {PriceString}\n" +
                    $"{nameof(CurrencyCode)}: {CurrencyCode}\n" +
-				   $"{nameof(ProductCategory)}: {ProductCategory}\n" +
+                   $"{nameof(ProductCategory)}: {ProductCategory}\n" +
                    $"{nameof(PresentedOfferingIdentifier)}: {PresentedOfferingIdentifier}\n" +
-                   $"{DefaultOption}\n" +
-                   $"{SubscriptionOptions}\n" +
-                   $"{IntroductoryPrice}\n" +
+                   $"{nameof(PresentedOfferingContext)}: {PresentedOfferingContext}\n" +
+                   $"{nameof(DefaultOption)}: {DefaultOption}\n" +
+                   $"{nameof(SubscriptionOptions)}: {SubscriptionOptions}\n" +
+                   $"{nameof(IntroductoryPrice)}: {IntroductoryPrice}\n" +
                    $"{nameof(Discounts)}: {Discounts}\n" +
                    $"{nameof(SubscriptionPeriod)}: {SubscriptionPeriod}";
         }


### PR DESCRIPTION
With https://github.com/RevenueCat/purchases-hybrid-common/pull/952 I realized that the docs were missing