### PR TITLE
Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 55a045588e724ea7717423daac11b85718044174
+  revision: 05ef0952ecb3b92398a0185a3f74019abd0c1d95
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -195,11 +195,14 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    mime-types (3.5.2)
+    logger (1.6.6)
+    mime-types (3.6.0)
+      logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0903)
+    mime-types-data (3.2025.0304)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     multi_json (1.15.0)
     multipart-post (2.4.1)
     nanaimo (0.4.0)
@@ -207,11 +210,8 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     nkf (0.2.0)
-    nokogiri (1.16.7-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.18.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (9.2.0)
       faraday (>= 1, < 3)


### PR DESCRIPTION
This updates the fastlane plugin to the latest version. I'm not sure why dependabot is not picking these automatically, and I didn't find anything after a cursory glance, so decided to just update it manually for now.
