### PR TITLE
Add `getStorefront` API

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -41,6 +41,12 @@ public class PurchasesAPITests : MonoBehaviour
         bool receivedUserCancelled;
         Purchases.LogLevel receivedLogLevel;
         String receivedMessage;
+        Purchases.Storefront? receivedStorefront;
+
+        purchases.GetStorefront((storefront) =>
+        {
+            receivedStorefront = storefront;
+        });
 
         List<Purchases.StoreProduct> receivedProducts = new List<Purchases.StoreProduct>();
 

--- a/IntegrationTests/Assets/APITests/StorefrontAPITests.cs
+++ b/IntegrationTests/Assets/APITests/StorefrontAPITests.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class StorefrontAPITests : MonoBehaviour
+    {
+        private void Start()
+        {
+            Purchases.Storefront storefront = new Purchases.Storefront(null);
+            string countryCode = storefront.CountryCode;
+        }
+    }
+}

--- a/IntegrationTests/Assets/APITests/StorefrontAPITests.cs.meta
+++ b/IntegrationTests/Assets/APITests/StorefrontAPITests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd45c0ab70e34409bad6668428b54d6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PurchasesWrapper {
+    private static final String RECEIVE_STOREFRONT = "_receiveStorefront";
     private static final String RECEIVE_PRODUCTS = "_receiveProducts";
     private static final String GET_CUSTOMER_INFO = "_getCustomerInfo";
     private static final String MAKE_PURCHASE = "_makePurchase";
@@ -89,6 +90,17 @@ public class PurchasesWrapper {
                 dangerousSettings, shouldShowInAppMessagesAutomatically, entitlementVerificationMode,
                 pendingTransactionsForPrepaidPlansEnabled);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(listener);
+    }
+
+    public static void getStorefront() {
+        CommonKt.getStorefront(storefrontMap -> {
+            if (storefrontMap != null) {
+                sendJSONObject(MappersHelpersKt.convertToJson(storefrontMap), RECEIVE_STOREFRONT);
+            } else {
+                sendEmptyJSONObject(RECEIVE_STOREFRONT);
+            }
+            return null;
+        });
     }
 
     public static void getProducts(String jsonProducts, String type) {
@@ -650,6 +662,10 @@ public class PurchasesWrapper {
 
     private static void logJSONException(JSONException e) {
         Log.e("Purchases", "JSON Error: " + e.getLocalizedMessage());
+    }
+
+    static void sendEmptyJSONObject(String method) {
+        UnityPlayer.UnitySendMessage(gameObject, method, "{}");
     }
 
     static void sendJSONObject(JSONObject object, String method) {

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -10,6 +10,7 @@
 @import PurchasesHybridCommon;
 @import RevenueCat;
 
+static NSString *const RECEIVE_STOREFRONT = @"_receiveStorefront";
 static NSString *const RECEIVE_PRODUCTS = @"_receiveProducts";
 static NSString *const RECEIVE_CUSTOMER_INFO = @"_receiveCustomerInfo";
 static NSString *const RESTORE_PURCHASES = @"_restorePurchases";
@@ -113,6 +114,16 @@ shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
             @"products": productObjects
         };
         [self sendJSONObject:response toMethod:RECEIVE_PRODUCTS];
+    }];
+}
+
+- (void)getStorefront {
+    [RCCommonFunctionality getStorefrontWithCompletion:^(NSDictionary *_Nullable responseDictionary) {
+        if (responseDictionary == nil) {
+            [self sendEmptyResponseToMethod:RECEIVE_STOREFRONT];
+        } else {
+            [self sendJSONObject:responseDictionary toMethod:RECEIVE_STOREFRONT];
+        }
     }];
 }
 
@@ -585,6 +596,10 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 
 #pragma mark Helper Methods
 
+- (void)sendEmptyResponseToMethod:(NSString *)methodName {
+    UnitySendMessage(self.gameObject.UTF8String, methodName.UTF8String, "{}");
+}
+
 - (void)sendJSONObject:(NSDictionary *)jsonObject toMethod:(NSString *)methodName {
     NSError *error = nil;
     NSData *responseJSONData = [NSJSONSerialization dataWithJSONObject:jsonObject options:0 error:&error];
@@ -666,6 +681,10 @@ void _RCSetupPurchases(const char *gameObject,
                      dangerousSettingsJson:convertCString(dangerousSettingsJson)
       shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
                entitlementVerificationMode:convertCString(entitlementVerificationMode)];
+}
+
+void _RCGetStorefront() {
+    [_RCUnityHelperShared() getStorefront];
 }
 
 void _RCGetProducts(const char *productIdentifiersJSON, const char *type) {

--- a/RevenueCat/Runtime.meta
+++ b/RevenueCat/Runtime.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 17d2113e8cd244381804b23f3647116c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -221,6 +221,7 @@ public partial class Purchases : MonoBehaviour
 
     /// <summary>
     /// Fetches the <c>Storefront</c> for the customer's current store account.
+    /// If there is an error, the callback will be called with a null value.
     /// </summary>
     public void GetStorefront(GetStorefrontFunc callback)
     {

--- a/RevenueCat/Scripts/PurchasesWrapper.cs
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs
@@ -12,6 +12,7 @@ public interface IPurchasesWrapper
         bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
         bool pendingTransactionsForPrepaidPlansEnabled);
 
+    void GetStorefront();
     void GetProducts(string[] productIdentifiers, string type = "subs");
 
     void PurchaseProduct(string productIdentifier, string type = "subs", string oldSku = null,

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -11,6 +11,11 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
         public string[] productIdentifiers;
     }
 
+    public void GetStorefront()
+    {
+        CallPurchases("getStorefront");
+    }
+
     public void GetProducts(string[] productIdentifiers, string type = "subs")
     {
         var request = new ProductsRequest

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs
@@ -17,6 +17,10 @@ public partial class Purchases
         {
         }
 
+        public void GetStorefront()
+        {
+        }
+
         public void GetProducts(string[] productIdentifiers, string type = "subs")
         {
         }

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -29,6 +29,13 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
             userDefaultsSuiteName, dangerousSettingsJson, shouldShowInAppMessagesAutomatically, entitlementVerificationMode.Name());
     }
 
+    [DllImport("__Internal")]
+    private static extern void _RCGetStorefront();
+    public void GetStorefront()
+    {
+        _RCGetStorefront();
+    }
+
     [SuppressMessage("ReSharper", "NotAccessedField.Local")]
     private class ProductsRequest
     {

--- a/RevenueCat/Scripts/Storefront.cs
+++ b/RevenueCat/Scripts/Storefront.cs
@@ -1,0 +1,25 @@
+using RevenueCat.SimpleJSON;
+
+public partial class Purchases
+{
+    /// <summary>
+    /// Contains the information about the current store account.
+    /// </summary>
+    public class Storefront
+    {
+        /// <summary>
+        /// Country code of the current store account.
+        /// </summary>
+        public readonly string CountryCode;
+
+        public Storefront(string countryCode)
+        {
+            CountryCode = countryCode;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(CountryCode)}: {CountryCode}";
+        }
+    }
+}

--- a/RevenueCat/Scripts/Storefront.cs.meta
+++ b/RevenueCat/Scripts/Storefront.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ebf0047457574fcda748e2c54408c6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Subtester/Assets/Scripts/PurchasesListener.cs
+++ b/Subtester/Assets/Scripts/PurchasesListener.cs
@@ -62,6 +62,7 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
         CreateButton("Fetch & Redeem WinBack for Product", FetchAndRedeemWinBackForProduct);
         CreateButton("Purchase Package For WinBack Testing", PurchasePackageForWinBackTesting);
         CreateButton("Fetch & Redeem WinBack for Package", FetchAndRedeemWinBackForPackage);
+        CreateButton("Get Storefront", GetStorefront);
 
         var purchases = GetComponent<Purchases>();
         purchases.SetLogLevel(Purchases.LogLevel.Verbose);
@@ -78,6 +79,22 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                 prorationMode = mode;
             });
         }
+    }
+
+    private void GetStorefront()
+    {
+        var purchases = GetComponent<Purchases>();
+        purchases.GetStorefront((storefront) =>
+        {
+            if (storefront == null)
+            {
+                infoLabel.text = "Storefront is null";
+            }
+            else
+            {
+                infoLabel.text = "Storefront: " + storefront.CountryCode;
+            }
+        });
     }
 
     private void CreatePurchasePackageButtons()


### PR DESCRIPTION
This adds a new API `Purchases.getStorefront` that returns an object of type `Storefront` which currently contains the country code to which the current Play store/App store/Amazon store account belongs to. In case there is an error fetching it, it will return null. 