### PR TITLE
Change result of purchase methods to PurchaseResult

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchaseResultAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchaseResultAPITests.cs
@@ -1,0 +1,18 @@
+using System;
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class PurchaseResultAPITests : MonoBehaviour
+    {
+        private void Start()
+        {
+            Purchases.PurchaseResult purchaseResult = new Purchases.PurchaseResult(null);
+            Purchases.StoreTransaction storeTransaction = purchaseResult.StoreTransaction;
+            Purchases.CustomerInfo customerInfo = purchaseResult.CustomerInfo;
+            bool userCancelled = purchaseResult.UserCancelled;
+            Purchases.Error error = purchaseResult.Error;
+            string productIdentifier = purchaseResult.ProductIdentifier;
+        }
+    }
+}

--- a/IntegrationTests/Assets/APITests/PurchaseResultAPITests.cs.meta
+++ b/IntegrationTests/Assets/APITests/PurchaseResultAPITests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f57212aadb5484cf6b7a6eeb75bb24ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -34,6 +34,8 @@ public class PurchasesAPITests : MonoBehaviour
         Purchases.Error receivedError;
         Purchases.StoreTransaction receivedTransaction;
 
+        Purchases.PurchaseResult receivedPurchaseResult;
+
         Purchases.Package receivedPackage;
         Purchases.Offerings receivedOfferings;
         Purchases.Offering receivedOffering;
@@ -65,30 +67,21 @@ public class PurchasesAPITests : MonoBehaviour
             receivedOffering = receivedOfferings.All.First().Value;
 
             receivedPackage = receivedOffering.AvailablePackages.First();
-            purchases.PurchasePackage(receivedPackage, (productIdentifier, customerInfo, userCancelled, error2) =>
+            purchases.PurchasePackage(receivedPackage, (purchaseResult) =>
             {
-                receivedProductIdentifier = productIdentifier;
-                receivedCustomerInfo = customerInfo;
-                receivedUserCancelled = userCancelled;
-                receivedError = error2;
+                receivedPurchaseResult = purchaseResult;
             });
 
-            purchases.PurchasePackage(receivedPackage, (productIdentifier, customerInfo, userCancelled, error2) =>
+            purchases.PurchasePackage(receivedPackage, (purchaseResult) =>
             {
-                receivedProductIdentifier = productIdentifier;
-                receivedCustomerInfo = customerInfo;
-                receivedUserCancelled = userCancelled;
-                receivedError = error2;
+                receivedPurchaseResult = purchaseResult;
             }, "oldSku", Purchases.ProrationMode.ImmediateWithoutProration);
 
             Purchases.StoreProduct storeProduct = storeProducts.First();
             Purchases.SubscriptionOption subscriptionOption = storeProduct.DefaultOption;
-            purchases.PurchaseSubscriptionOption(subscriptionOption, (productIdentifier, customerInfo, userCancelled, error) =>
+            purchases.PurchaseSubscriptionOption(subscriptionOption, (purchaseResult) =>
             {
-                receivedProductIdentifier = productIdentifier;
-                receivedCustomerInfo = customerInfo;
-                receivedUserCancelled = userCancelled;
-                receivedError = error;
+                receivedPurchaseResult = purchaseResult;
             }, null, false);
 
             Purchases.PromotionalOffer receivedPromoOffer;
@@ -98,39 +91,27 @@ public class PurchasesAPITests : MonoBehaviour
                 receivedError = error2;
 
                 purchases.PurchaseDiscountedPackage(receivedPackage, receivedPromoOffer,
-                    (productIdentifier, purchaserInfo, userCancelled, error3) =>
+                    (purchaseResult) =>
                     {
-                        receivedProductIdentifier = productIdentifier;
-                        receivedCustomerInfo = purchaserInfo;
-                        receivedUserCancelled = userCancelled;
-                        receivedError = error3;
+                        receivedPurchaseResult = purchaseResult;
                     });
 
                 purchases.PurchaseDiscountedProduct("product_id", receivedPromoOffer,
-                    (productIdentifier, purchaserInfo, userCancelled, error3) =>
+                    (purchaseResult) =>
                     {
-                        receivedProductIdentifier = productIdentifier;
-                        receivedCustomerInfo = purchaserInfo;
-                        receivedUserCancelled = userCancelled;
-                        receivedError = error3;
+                        receivedPurchaseResult = purchaseResult;
                     });
             });
         });
 
-        purchases.PurchaseProduct("product_id", (productIdentifier, customerInfo, userCancelled, error2) =>
+        purchases.PurchaseProduct("product_id", (purchaseResult) =>
         {
-            receivedProductIdentifier = productIdentifier;
-            receivedCustomerInfo = customerInfo;
-            receivedUserCancelled = userCancelled;
-            receivedError = error2;
+            receivedPurchaseResult = purchaseResult;
         });
 
-        purchases.PurchaseProduct("product_id", (productIdentifier, purchaserInfo, userCancelled, error2) =>
+        purchases.PurchaseProduct("product_id", (purchaseResult) =>
         {
-            receivedProductIdentifier = productIdentifier;
-            receivedCustomerInfo = purchaserInfo;
-            receivedUserCancelled = userCancelled;
-            receivedError = error2;
+            receivedPurchaseResult = purchaseResult;
         }, "type", "oldSku", Purchases.ProrationMode.ImmediateWithoutProration);
 
         purchases.RestorePurchases((customerInfo, error) =>
@@ -258,8 +239,9 @@ public class PurchasesAPITests : MonoBehaviour
             purchases.GetEligibleWinBackOffersForProduct(products[0], (winBackOffers, error2) =>
             {
                 purchases.PurchaseProductWithWinBackOffer(products[0], winBackOffers[0], 
-                    (productIdentifier, customerInfo, userCancelled, purchaseError) =>
+                    (purchaseResult) =>
                 {
+                    receivedPurchaseResult = purchaseResult;
                 });
             });
         });
@@ -271,8 +253,9 @@ public class PurchasesAPITests : MonoBehaviour
             purchases.GetEligibleWinBackOffersForPackage(package, (winBackOffers, error2) =>
             {
                 purchases.PurchasePackageWithWinBackOffer(package, winBackOffers[0], 
-                    (productIdentifier, customerInfo, userCancelled, purchaseError) =>
+                    (purchaseResult) =>
                 {
+                    receivedPurchaseResult = purchaseResult;
                 });
             });
         });

--- a/IntegrationTests/Assets/APITests/StoreTransactionAPITests.cs
+++ b/IntegrationTests/Assets/APITests/StoreTransactionAPITests.cs
@@ -9,9 +9,7 @@ namespace DefaultNamespace
         {
             Purchases.StoreTransaction storeTransaction = new Purchases.StoreTransaction(null);
             string transactionIdentifier = storeTransaction.TransactionIdentifier;
-            string revenueCatId = storeTransaction.RevenueCatId;
             string productIdentifier = storeTransaction.ProductIdentifier;
-            string productId = storeTransaction.ProductId;
             DateTime purchaseDate = storeTransaction.PurchaseDate;
         }
     }

--- a/RevenueCat/Scripts/PurchaseResult.cs
+++ b/RevenueCat/Scripts/PurchaseResult.cs
@@ -1,0 +1,81 @@
+using System;
+using RevenueCat.SimpleJSON;
+using static RevenueCat.Utilities;
+
+
+public partial class Purchases
+{
+    /// <summary>
+    /// Class containing the data of the result of a purchase.
+    /// </summary>
+    public class PurchaseResult
+    {
+        /**
+         * <summary>
+         * The updated <see cref="CustomerInfo"/> object after the successful purchase.
+         * </summary>
+         */
+        public readonly CustomerInfo CustomerInfo;
+
+        /**
+         * <summary>
+         * The product identifier for which the purchase was attempted.
+         * </summary>
+         */
+        public readonly string ProductIdentifier;
+
+        /**
+         * <summary>
+         * A boolean that indicates whether the purchase was cancelled by the user.
+         * </summary>
+         */
+        public readonly bool UserCancelled;
+
+        /**
+         * <summary>
+         * An error, if one occurred. Null if the purchase was successful.
+         * </summary>
+         */
+        public readonly Error Error;
+
+        /**
+         * <summary>
+         * The <see cref="StoreTransaction"/> object for the purchase that just happened. Null if the purchase was not successful.
+         * </summary>
+         */
+        public readonly StoreTransaction StoreTransaction;
+
+        public PurchaseResult(JSONNode response)
+        {
+            if (response["customerInfo"] != null)
+            {
+                CustomerInfo = new CustomerInfo(response["customerInfo"]);
+            }
+
+            if (response["transaction"] != null)
+            {
+                StoreTransaction = new StoreTransaction(response["transaction"]);
+                ProductIdentifier = StoreTransaction.ProductIdentifier;
+            }
+
+            if (response["userCancelled"] != null)
+            {
+                UserCancelled = response["userCancelled"].AsBool;
+            }
+
+            if (response["error"] != null)
+            {
+                Error = new Error(response["error"]);
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(CustomerInfo)}: {CustomerInfo}\n" +
+                   $"{nameof(ProductIdentifier)}: {ProductIdentifier}\n" +
+                   $"{nameof(UserCancelled)}: {UserCancelled}\n" +
+                   $"{nameof(Error)}: {Error}\n" +
+                   $"{nameof(StoreTransaction)}: {StoreTransaction}";
+        }
+    }
+}

--- a/RevenueCat/Scripts/PurchaseResult.cs.meta
+++ b/RevenueCat/Scripts/PurchaseResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 186f8d50bbb1e4ba68bd519bc63f7479
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -275,12 +275,8 @@ public partial class Purchases : MonoBehaviour
     /// and <see cref="Purchases.PurchasePackageWithWinBackOffer"/>.
     /// </summary>
     ///
-    /// <param name="productIdentifier"> The product identifier for which the purchase was attempted.</param>
-    /// <param name="customerInfo"> The updated <see cref="CustomerInfo"/> object after the successful purchase.</param>
-    /// <param name="userCancelled"> A boolean that indicates whether the purchase was cancelled by the user.</param>
-    /// <param name="error"> An error, if one occurred. Null if the purchase was successful. </param>
-    public delegate void MakePurchaseFunc(string productIdentifier, CustomerInfo customerInfo, bool userCancelled,
-        Error error);
+    /// <param name="purchaseResult"> The <see cref="PurchaseResult"/> object for the purchase attempt that just happened.</param>
+    public delegate void MakePurchaseFunc(PurchaseResult purchaseResult);
 
     private MakePurchaseFunc MakePurchaseCallback { get; set; }
 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -1419,18 +1419,7 @@ public partial class Purchases : MonoBehaviour
         MakePurchaseCallback = null;
 
         var response = JSON.Parse(makePurchaseResponseJson);
-
-        if (ResponseHasError(response))
-        {
-            callback(null, null, response["userCancelled"],
-                new Error(response["error"]));
-        }
-        else
-        {
-            var info = new CustomerInfo(response["customerInfo"]);
-            var productIdentifier = response["productIdentifier"];
-            callback(productIdentifier, info, false, null);
-        }
+        callback(new PurchaseResult(response));
     }
 
     // ReSharper disable once UnusedMember.Local
@@ -1766,17 +1755,7 @@ public partial class Purchases : MonoBehaviour
         var callback = MakePurchaseCallback;
         MakePurchaseCallback = null;
 
-        if (ResponseHasError(response))
-        {
-            callback(null, null, response["userCancelled"], new Error(response["error"]));
-        }
-        else
-        {
-            var info = new CustomerInfo(response["customerInfo"]);
-            var productIdentifier = response["productIdentifier"];
-            callback(productIdentifier, info, false, null);
-        }
-
+        callback(new PurchaseResult(response));
     }
 
     private void _purchasePackageWithWinBackOffer(string purchasePackageWithWinBackOfferJson)
@@ -1789,16 +1768,7 @@ public partial class Purchases : MonoBehaviour
         var callback = MakePurchaseCallback;
         MakePurchaseCallback = null;
 
-        if (ResponseHasError(response))
-        {
-            callback(null, null, response["userCancelled"], new Error(response["error"]));
-        }
-        else
-        {
-            var info = new CustomerInfo(response["customerInfo"]);
-            var productIdentifier = response["productIdentifier"];
-            callback(productIdentifier, info, false, null);
-        }
+        callback(new PurchaseResult(response));
     }
 
     private static void ReceiveCustomerInfoMethod(string arguments, CustomerInfoFunc callback)

--- a/RevenueCat/Scripts/StoreTransaction.cs
+++ b/RevenueCat/Scripts/StoreTransaction.cs
@@ -17,23 +17,7 @@ public partial class Purchases
          * Id associated with the transaction in RevenueCat.
          * </summary>
          */
-        [Obsolete("Deprecated, use TransactionIdentifier instead.", false)]
-        public readonly string RevenueCatId;
-
-        /**
-         * <summary>
-         * Id associated with the transaction in RevenueCat.
-         * </summary>
-         */
         public readonly string TransactionIdentifier;
-
-        /**
-         * <summary>
-         * Product Id associated with the transaction.
-         * </summary>
-         */
-        [Obsolete("Deprecated, use ProductIdentifier instead.", false)]
-        public readonly string ProductId;
 
         /**
          * <summary>
@@ -53,22 +37,14 @@ public partial class Purchases
         {
             TransactionIdentifier = response["transactionIdentifier"];
             ProductIdentifier = response["productIdentifier"];
-            #pragma warning disable 618 // Disable Obsolete warning
-            RevenueCatId = response["transactionIdentifier"];
-            ProductId = response["productIdentifier"];
-            #pragma warning restore 618
             PurchaseDate = FromUnixTimeInMilliseconds(response["purchaseDateMillis"].AsLong);
         }
 
         public override string ToString()
         {
-            #pragma warning disable 618 // Disable Obsolete warning
             return $"{nameof(TransactionIdentifier)}: {TransactionIdentifier}\n" +
-                   $"{nameof(RevenueCatId)}: {RevenueCatId}\n" +
                    $"{nameof(ProductIdentifier)}: {ProductIdentifier}\n" +
-                   $"{nameof(ProductId)}: {ProductId}\n" +
                    $"{nameof(PurchaseDate)}: {PurchaseDate}";
-            #pragma warning restore 618
         }
     }
 }

--- a/Subtester/Assets/Scripts/PurchasesListener.cs
+++ b/Subtester/Assets/Scripts/PurchasesListener.cs
@@ -247,17 +247,18 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
     private void PurchaseProductButtonClicked(Purchases.StoreProduct storeProduct)
     {
         var purchases = GetComponent<Purchases>();
-        purchases.PurchaseProduct(storeProduct.Identifier, (productIdentifier, customerInfo, userCancelled, error) =>
+        purchases.PurchaseProduct(storeProduct.Identifier, (purchaseResult) =>
         {
-            if (!userCancelled)
+            if (!purchaseResult.UserCancelled)
             {
-                if (error != null)
+                if (purchaseResult.Error != null)
                 {
-                    LogError(error);
+                    LogError(purchaseResult.Error);
                 }
                 else
                 {
-                    DisplayCustomerInfo(customerInfo);
+                    DisplayCustomerInfo(purchaseResult.CustomerInfo);
+                    Debug.Log("StoreTransaction: " + purchaseResult.StoreTransaction);
                 }
             }
             else
@@ -271,17 +272,18 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
     private void PurchasePackageButtonClicked(Purchases.Package package)
     {
         var purchases = GetComponent<Purchases>();
-        purchases.PurchasePackage(package, (productIdentifier, customerInfo, userCancelled, error) =>
+        purchases.PurchasePackage(package, (purchaseResult) =>
         {
-            if (!userCancelled)
+            if (!purchaseResult.UserCancelled)
             {
-                if (error != null)
+                if (purchaseResult.Error != null)
                 {
-                    LogError(error);
+                    LogError(purchaseResult.Error);
                 }
                 else
                 {
-                    DisplayCustomerInfo(customerInfo);
+                    DisplayCustomerInfo(purchaseResult.CustomerInfo);
+                    Debug.Log("StoreTransaction: " + purchaseResult.StoreTransaction);
                 }
             }
             else
@@ -298,17 +300,18 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
             googleProductChangeInfo = new Purchases.GoogleProductChangeInfo(currentProductId, prorationMode);
         }
         var purchases = GetComponent<Purchases>();
-        purchases.PurchaseSubscriptionOption(subscriptionOption, (productIdentifier, customerInfo, userCancelled, error) =>
+        purchases.PurchaseSubscriptionOption(subscriptionOption, (purchaseResult) =>
         {
-            if (!userCancelled)
+            if (!purchaseResult.UserCancelled)
             {
-                if (error != null)
+                if (purchaseResult.Error != null)
                 {
-                    LogError(error);
+                    LogError(purchaseResult.Error);
                 }
                 else
                 {
-                    DisplayCustomerInfo(customerInfo);
+                    DisplayCustomerInfo(purchaseResult.CustomerInfo);
+                    Debug.Log("StoreTransaction: " + purchaseResult.StoreTransaction);
                 }
             }
             else
@@ -622,23 +625,23 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                             else
                             {
                                 purchases.PurchaseDiscountedProduct(storeProduct.Identifier, promoOffer,
-                                    (identifier, customerInfo, cancelled, purchaseError) =>
+                                    (purchaseResult) =>
                                     {
-                                        if (purchaseError != null)
+                                        if (purchaseResult.Error != null)
                                         {
-                                            if (cancelled)
+                                            if (purchaseResult.UserCancelled)
                                             {
                                                 infoLabel.text = "purchase cancelled!";
                                             }
                                             else
                                             {
-                                                LogError(purchaseError);
+                                                LogError(purchaseResult.Error);
                                             }
                                         }
                                         else
                                         {
                                             infoLabel.text +=
-                                                $"Purchase of {identifier} successful!\ncustomerInfo:\n{customerInfo}";
+                                                $"Purchase of {purchaseResult.ProductIdentifier} successful!\ncustomerInfo:\n{purchaseResult.CustomerInfo}";
                                         }
                                     });
                             }
@@ -683,23 +686,23 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                             else
                             {
                                 purchases.PurchaseDiscountedProduct(package.StoreProduct.Identifier, promoOffer,
-                                    (identifier, customerInfo, cancelled, purchaseError) =>
+                                    (purchaseResult) =>
                                     {
-                                        if (purchaseError != null)
+                                        if (purchaseResult.Error != null)
                                         {
-                                            if (cancelled)
+                                            if (purchaseResult.UserCancelled)
                                             {
                                                 infoLabel.text = "purchase cancelled!";
                                             }
                                             else
                                             {
-                                                LogError(purchaseError);
+                                                LogError(purchaseResult.Error);
                                             }
                                         }
                                         else
                                         {
                                             infoLabel.text +=
-                                                $"Purchase of {identifier} successful!\ncustomerInfo:\n{customerInfo}";
+                                                $"Purchase of {purchaseResult.ProductIdentifier} successful!\ncustomerInfo:\n{purchaseResult.CustomerInfo}";
                                         }
                                     });
                             }
@@ -848,18 +851,18 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                             }
                             infoLabel.text = offerText;
 
-                            purchases.PurchaseProductWithWinBackOffer(product, winBackOffers[0], (productIdentifier, customerInfo, userCancelled, purchaseError) =>
+                            purchases.PurchaseProductWithWinBackOffer(product, winBackOffers[0], (purchaseResult) =>
                             {
-                                if (purchaseError != null)
+                                if (purchaseResult.Error != null)
                                 {
-                                    LogError(purchaseError);
-                                    Debug.Log($"productIdentifier: {productIdentifier}, customerInfo: {customerInfo}, userCancelled: {userCancelled}, purchaseError: {purchaseError}");
+                                    LogError(purchaseResult.Error);
+                                    Debug.Log($"productIdentifier: {purchaseResult.ProductIdentifier}, customerInfo: {purchaseResult.CustomerInfo}, userCancelled: {purchaseResult.UserCancelled}, purchaseError: {purchaseResult.Error}");
                                     return;
                                 }
                                 else
                                 {
-                                    infoLabel.text = $"Purchase of {productIdentifier} successful!\ncustomerInfo:\n{customerInfo}";
-                                    Debug.Log($"productIdentifier: {productIdentifier}, customerInfo: {customerInfo}, userCancelled: {userCancelled}, purchaseError: {purchaseError}");
+                                    infoLabel.text = $"Purchase of {purchaseResult.ProductIdentifier} successful!\ncustomerInfo:\n{purchaseResult.CustomerInfo}";
+                                    Debug.Log($"productIdentifier: {purchaseResult.ProductIdentifier}, customerInfo: {purchaseResult.CustomerInfo}, userCancelled: {purchaseResult.UserCancelled}, purchaseError: {purchaseResult.Error}");
                                 }
                             });
                         }
@@ -930,18 +933,18 @@ public class PurchasesListener : Purchases.UpdatedCustomerInfoListener
                             infoLabel.text = offerText;
 
                             purchases.PurchasePackageWithWinBackOffer(package, winBackOffers[0],
-                                (productIdentifier, customerInfo, userCancelled, purchaseError) =>
+                                (purchaseResult) =>
                                 {
-                                    if (purchaseError != null)
+                                    if (purchaseResult.Error != null)
                                     {
-                                        LogError(purchaseError);
-                                        Debug.Log($"productIdentifier: {productIdentifier}, customerInfo: {customerInfo}, userCancelled: {userCancelled}, purchaseError: {purchaseError}");
+                                        LogError(purchaseResult.Error);
+                                        Debug.Log($"productIdentifier: {purchaseResult.ProductIdentifier}, customerInfo: {purchaseResult.CustomerInfo}, userCancelled: {purchaseResult.UserCancelled}, purchaseError: {purchaseResult.Error}");
                                         return;
                                     }
                                     else
                                     {
-                                        infoLabel.text = $"Purchase of {productIdentifier} successful!\ncustomerInfo:\n{customerInfo}";
-                                        Debug.Log($"productIdentifier: {productIdentifier}, customerInfo: {customerInfo}, userCancelled: {userCancelled}, purchaseError: {purchaseError}");
+                                        infoLabel.text = $"Purchase of {purchaseResult.ProductIdentifier} successful!\ncustomerInfo:\n{purchaseResult.CustomerInfo}";
+                                        Debug.Log($"productIdentifier: {purchaseResult.ProductIdentifier}, customerInfo: {purchaseResult.CustomerInfo}, userCancelled: {purchaseResult.UserCancelled}, purchaseError: {purchaseResult.Error}");
                                     }
                                 });
                         }


### PR DESCRIPTION
This changes the result type of the purchase methods. Instead of returning a func with different parameters, we now return an object containing all the fields, which can make it more extensible.
