### PR TITLE
Add pricePerWeek/Month/Year convenience properties to StoreProduct

### DIFF
--- a/IntegrationTests/Assets/APITests/StoreProductAPITests.cs
+++ b/IntegrationTests/Assets/APITests/StoreProductAPITests.cs
@@ -14,6 +14,12 @@ namespace DefaultNamespace
             string description = storeProduct.Description;
             float price = storeProduct.Price;
             string priceString = storeProduct.PriceString;
+            float? pricePerWeek = storeProduct.PricePerWeek;
+            float? pricePerMonth = storeProduct.PricePerMonth;
+            float? pricePerYear = storeProduct.PricePerYear;
+            string? pricePerWeekString = storeProduct.PricePerWeekString;
+            string? pricePerMonthString = storeProduct.PricePerMonthString;
+            string? pricePerYearString = storeProduct.PricePerYearString;
             string currencyCode = storeProduct.CurrencyCode;
             float introPrice = storeProduct.IntroductoryPrice.Price;
             string introPriceString = storeProduct.IntroductoryPrice.PriceString;

--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -43,40 +43,58 @@ public partial class Purchases
         public readonly string PriceString;
 
         /// <summary>
-        /// Price of the product per week. Null for non-subscription products.
+        /// Null for non-subscription products. The price of the StoreProduct in a weekly recurrence.
+        /// This means that, for example, if the period is monthly, the price will be
+        /// divided by 4. Note that this value may be an approximation. For Google subscriptions,
+        /// this value will use the basePlan to calculate the value.
         /// </summary>
         /// <returns></returns>
         public readonly float? PricePerWeek;
 
         /// <summary>
-        /// Price of the product per month. Null for non-subscription products.
+        /// Null for non-subscription products. The price of the StoreProduct in a monthly recurrence.
+        /// This means that, for example, if the period is yearly, the price will be
+        /// divided by 12. Note that this value may be an approximation. For Google subscriptions,
+        /// this value will use the basePlan to calculate the value.
         /// </summary>
         /// <returns></returns>
         public readonly float? PricePerMonth;
 
         /// <summary>
-        /// Price of the product per year. Null for non-subscription products.
+        /// Null for non-subscription products. The price of the StoreProduct in a yearly recurrence.
+        /// This means that, for example, if the period is monthly, the price will be
+        /// multiplied by 12. Note that this value may be an approximation. For Google subscriptions,
+        /// this value will use the basePlan to calculate the value.
         /// </summary>
         /// <returns></returns>
         public readonly float? PricePerYear;
 
         /// <summary>
-        /// Formatted price of the item per week, including its currency sign.
-        /// Null for non-subscription products.
+        /// Null for non-subscription products. The price of the StoreProduct formatted for the current
+        /// locale in a weekly recurrence. This means that, for example, if the period is monthly,
+        /// the price will be divided by 4. It uses a currency formatter to format the price in the
+        /// given locale. Note that this value may be an approximation. For Google subscriptions,
+        /// this value will use the basePlan to calculate the value.
         /// </summary>
         /// <returns></returns>
         public readonly string? PricePerWeekString;
 
         /// <summary>
-        /// Formatted price of the item per month, including its currency sign.
-        /// Null for non-subscription products.
+        /// Null for non-subscription products. The price of the StoreProduct formatted for the current
+        /// locale in a monthly recurrence. This means that, for example, if the period is yearly,
+        /// the price will be divided by 12. It uses a currency formatter to format the price in the
+        /// given locale. Note that this value may be an approximation. For Google subscriptions,
+        /// this value will use the basePlan to calculate the value.
         /// </summary>
         /// <returns></returns>
         public readonly string? PricePerMonthString;
 
         /// <summary>
-        /// Formatted price of the item per year, including its currency sign.
-        /// Null for non-subscription products.
+        /// Null for non-subscription products. The price of the StoreProduct formatted for the current
+        /// locale in a yearly recurrence. This means that, for example, if the period is monthly,
+        /// the price will be multiplied by 12. It uses a currency formatter to format the price in the
+        /// given locale. Note that this value may be an approximation. For Google subscriptions,
+        /// this value will use the basePlan to calculate the value.
         /// </summary>
         /// <returns></returns>
         public readonly string? PricePerYearString;

--- a/RevenueCat/Scripts/StoreProduct.cs
+++ b/RevenueCat/Scripts/StoreProduct.cs
@@ -43,6 +43,45 @@ public partial class Purchases
         public readonly string PriceString;
 
         /// <summary>
+        /// Price of the product per week. Null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
+        public readonly float? PricePerWeek;
+
+        /// <summary>
+        /// Price of the product per month. Null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
+        public readonly float? PricePerMonth;
+
+        /// <summary>
+        /// Price of the product per year. Null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
+        public readonly float? PricePerYear;
+
+        /// <summary>
+        /// Formatted price of the item per week, including its currency sign.
+        /// Null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
+        public readonly string? PricePerWeekString;
+
+        /// <summary>
+        /// Formatted price of the item per month, including its currency sign.
+        /// Null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
+        public readonly string? PricePerMonthString;
+
+        /// <summary>
+        /// Formatted price of the item per year, including its currency sign.
+        /// Null for non-subscription products.
+        /// </summary>
+        /// <returns></returns>
+        public readonly string? PricePerYearString;
+
+        /// <summary>
         /// Currency code for price and original price.
         /// Contains the currency code of DefaultOption for Google Play.
         /// </summary>
@@ -110,6 +149,14 @@ public partial class Purchases
             PriceString = response["priceString"];
             CurrencyCode = response["currencyCode"];
             SubscriptionPeriod = response["subscriptionPeriod"];
+
+            PricePerWeek = response["pricePerWeek"];
+            PricePerMonth = response["pricePerMonth"];
+            PricePerYear = response["pricePerYear"];
+            PricePerWeekString = response["pricePerWeekString"];
+            PricePerMonthString = response["pricePerMonthString"];
+            PricePerYearString = response["pricePerYearString"];
+
             var introPriceJsonNode = response["introPrice"];
             if (introPriceJsonNode != null && !introPriceJsonNode.IsNull)
             {
@@ -170,6 +217,12 @@ public partial class Purchases
                    $"{nameof(Description)}: {Description}\n" +
                    $"{nameof(Price)}: {Price}\n" +
                    $"{nameof(PriceString)}: {PriceString}\n" +
+                   $"{nameof(PricePerWeek)}: {PricePerWeek}\n" +
+                   $"{nameof(PricePerMonth)}: {PricePerMonth}\n" +
+                   $"{nameof(PricePerYear)}: {PricePerYear}\n" +
+                   $"{nameof(PricePerWeekString)}: {PricePerWeekString}\n" +
+                   $"{nameof(PricePerMonthString)}: {PricePerMonthString}\n" +
+                   $"{nameof(PricePerYearString)}: {PricePerYearString}\n" +
                    $"{nameof(CurrencyCode)}: {CurrencyCode}\n" +
                    $"{nameof(ProductCategory)}: {ProductCategory}\n" +
                    $"{nameof(PresentedOfferingIdentifier)}: {PresentedOfferingIdentifier}\n" +


### PR DESCRIPTION
Adds new `pricePerWeek`, `pricePerMonth`, `pricePerYear`, `pricePerWeekString`, `pricePerMonthString`, `pricePerYearString` properties to `StoreProduct