### PR TITLE
Show iOS Paywall 

### DIFF
--- a/RevenueCatUI/Plugins/Editor.meta
+++ b/RevenueCatUI/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31d4fa322f651478dbc9ed0bed0ef2a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCatUI/Plugins/Editor/RevenueCatUIDependencies.xml
+++ b/RevenueCatUI/Plugins/Editor/RevenueCatUIDependencies.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dependencies>
+    <androidPackages>
+        <!-- No additional Android packages required here for POC -->
+    </androidPackages>
+    <iosPods>
+        <!-- RevenueCat UI for iOS (provides Paywall APIs) -->
+        <iosPod name="PurchasesHybridCommonUI" version="17.6.0" minTargetSdk="13.0"/>
+    </iosPods>
+</dependencies>
+

--- a/RevenueCatUI/Plugins/Editor/RevenueCatUIDependencies.xml.meta
+++ b/RevenueCatUI/Plugins/Editor/RevenueCatUIDependencies.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d67e7f1316a6e4d0a891121b43ad48c1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCatUI/Plugins/iOS/RevenueCatUI.m
+++ b/RevenueCatUI/Plugins/iOS/RevenueCatUI.m
@@ -1,37 +1,78 @@
+// RevenueCat UI iOS bridge implemented via PurchasesHybridCommonUI
 #import <Foundation/Foundation.h>
-
-// Minimal native stubs for iOS bridging
+@import PurchasesHybridCommonUI;
+// Import Swift interface for direct calls into PaywallProxy
+#import <PurchasesHybridCommonUI/PurchasesHybridCommonUI-Swift.h>
 
 typedef void (*RCUIPaywallResultCallback)(const char* result);
 typedef void (*RCUICustomerCenterCallback)(void);
 
+static NSString *RCUINormalizeResult(NSString *resultName) {
+    if (resultName == nil) {
+        return @"ERROR";
+    }
+    NSString *lower = [[resultName lowercaseString] stringByReplacingOccurrencesOfString:@"_" withString:@""];
+    if ([lower isEqualToString:@"purchased"]) return @"PURCHASED";
+    if ([lower isEqualToString:@"restored"]) return @"RESTORED";
+    if ([lower isEqualToString:@"cancelled"]) return @"CANCELLED";
+    if ([lower isEqualToString:@"error"]) return @"ERROR";
+    if ([lower isEqualToString:@"notpresented"]) return @"NOT_PRESENTED";
+    return @"ERROR";
+}
+
+static PaywallProxy *s_rcuiPaywallProxy = nil;
+
 void rcui_presentPaywall(const char* offeringIdentifier, bool displayCloseButton, RCUIPaywallResultCallback callback) {
-    NSLog(@"[RevenueCatUI][iOS] presentPaywall(offering=%@, closeButton=%@)",
-          offeringIdentifier ? [NSString stringWithUTF8String:offeringIdentifier] : @"<null>",
-          displayCloseButton ? @"true" : @"false");
-    if (callback) {
-        callback("CANCELLED|Stub: no native UI");
+    if (@available(iOS 15.0, *)) {
+        // Keep a strong reference to the proxy so the handler remains alive until dismissal
+        s_rcuiPaywallProxy = [[PaywallProxy alloc] init];
+        NSMutableDictionary *options = [NSMutableDictionary new];
+        options[@"displayCloseButton"] = @(displayCloseButton);
+        if (offeringIdentifier != NULL) {
+            NSString *offering = [NSString stringWithUTF8String:offeringIdentifier];
+            if (offering.length > 0) {
+                options[@"offeringIdentifier"] = offering;
+            }
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [s_rcuiPaywallProxy presentPaywallWithOptions:options paywallResultHandler:^(NSString * _Nonnull resultName) {
+                if (callback) {
+                    NSString *normalized = RCUINormalizeResult(resultName);
+                    // Allow attaching debug string after pipe if needed
+                    callback([normalized UTF8String]);
+                }
+                // Also notify via UnitySendMessage for robustness
+                NSString *normalized2 = RCUINormalizeResult(resultName);
+                UnitySendMessage("RevenueCatUIReceiver", "_rcuiPaywallResult", [normalized2 UTF8String]);
+                // Release retained proxy after result
+                s_rcuiPaywallProxy = nil;
+            }];
+        });
+    } else {
+        const char *fallback = "NOT_PRESENTED";
+        if (callback) { callback(fallback); }
+        UnitySendMessage("RevenueCatUIReceiver", "_rcuiPaywallResult", fallback);
     }
 }
 
 void rcui_presentPaywallIfNeeded(const char* requiredEntitlementIdentifier, const char* offeringIdentifier, bool displayCloseButton, RCUIPaywallResultCallback callback) {
-    NSLog(@"[RevenueCatUI][iOS] presentPaywallIfNeeded(entitlement=%@, offering=%@, closeButton=%@)",
-          requiredEntitlementIdentifier ? [NSString stringWithUTF8String:requiredEntitlementIdentifier] : @"<null>",
-          offeringIdentifier ? [NSString stringWithUTF8String:offeringIdentifier] : @"<null>",
-          displayCloseButton ? @"true" : @"false");
+    // TODO: entitlement check is not wired; return NOT_PRESENTED
     if (callback) {
-        callback("NOT_PRESENTED|Stub: no native UI");
+        callback("NOT_PRESENTED|TODO: entitlement check not implemented");
     }
 }
 
 void rcui_presentCustomerCenter(RCUICustomerCenterCallback callback) {
-    NSLog(@"[RevenueCatUI][iOS] presentCustomerCenter()");
+    // Not implemented in POC; simply invoke callback immediately.
     if (callback) {
         callback();
     }
 }
 
 bool rcui_isSupported() {
-    NSLog(@"[RevenueCatUI][iOS] isSupported() -> true (stub)");
-    return true;
+    if (@available(iOS 15.0, *)) {
+        return true;
+    }
+    return false;
 }

--- a/RevenueCatUI/README.md
+++ b/RevenueCatUI/README.md
@@ -102,6 +102,29 @@ var options = new PaywallOptions
 };
 ```
 
+### Callbacks and Fallback
+
+- Default: Pure code callbacks. `PresentPaywall(...)` returns a `Task<PaywallResult>` and uses a native function-pointer callback to complete it. No GameObject is created implicitly.
+- Optional fallback: UnitySendMessage. If your environment requires or you prefer a GameObject-based callback, opt in explicitly:
+
+```csharp
+// Optional: enable UnitySendMessage fallback
+RevenueCat.UI.RevenueCatUI.EnableUnityMessageFallback(); // or provide a custom receiver name
+
+// Present
+var result = await RevenueCat.UI.RevenueCatUI.PresentPaywall();
+```
+
+Disable fallback at any time:
+
+```csharp
+RevenueCat.UI.RevenueCatUI.DisableUnityMessageFallback();
+```
+
+Notes:
+- The fallback registers a persistent GameObject to receive callbacks from native via `UnitySendMessage`.
+- Pure-code remains the primary mechanism; fallback is off by default.
+
 ### PaywallResult
 
 ```csharp

--- a/RevenueCatUI/Scripts/PaywallCallbackReceiver.cs
+++ b/RevenueCatUI/Scripts/PaywallCallbackReceiver.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+namespace RevenueCat.UI
+{
+    // Ensures there's a GameObject to receive UnitySendMessage callbacks from native code
+    // Optional UnitySendMessage fallback receiver. Disabled by default.
+    // Use RevenueCatUI.EnableUnityMessageFallback to create/register this receiver.
+    [UnityEngine.Scripting.Preserve]
+    internal class PaywallCallbackReceiver : MonoBehaviour
+    {
+        private static string s_receiverName = "RevenueCatUIReceiver";
+        private static PaywallCallbackReceiver _instance;
+
+        internal static void EnsureExists(string receiverName = null)
+        {
+            if (_instance != null) return;
+            if (!string.IsNullOrEmpty(receiverName)) s_receiverName = receiverName;
+
+            var go = GameObject.Find(s_receiverName) ?? new GameObject(s_receiverName);
+            _instance = go.GetComponent<PaywallCallbackReceiver>() ?? go.AddComponent<PaywallCallbackReceiver>();
+            DontDestroyOnLoad(go);
+        }
+
+        internal static void Disable()
+        {
+            if (_instance == null) return;
+            var go = _instance.gameObject;
+            _instance = null;
+            if (go != null)
+            {
+                Object.Destroy(go);
+            }
+        }
+
+        // Called via UnitySendMessage from native iOS layer
+        // Method name must match exactly
+        [UnityEngine.Scripting.Preserve]
+        public void _rcuiPaywallResult(string payload)
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            Platforms.IOSPaywallPresenter.ReceiveResultFromUnityMessage(payload);
+#else
+            Debug.Log($"[RevenueCatUI] Received paywall result callback on unsupported platform: {payload}");
+#endif
+        }
+    }
+}

--- a/RevenueCatUI/Scripts/PaywallCallbackReceiver.cs.meta
+++ b/RevenueCatUI/Scripts/PaywallCallbackReceiver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8cc5e4fc007204a9d8ce9b0c3e7c2a3b

--- a/RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs
+++ b/RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs
@@ -15,8 +15,17 @@ namespace RevenueCat.UI.Platforms
 
         private static TaskCompletionSource<PaywallResult> s_current;
 
+        // Called from UnitySendMessage fallback path
+        internal static void ReceiveResultFromUnityMessage(string result)
+        {
+            OnResult(result);
+        }
+
         public bool IsSupported() => rcui_isSupported();
 
+        // Presents the paywall using native UI. Primary callback path uses a function-pointer
+        // delegate (OnResult). There is an optional UnitySendMessage fallback that can be enabled
+        // via RevenueCatUI.EnableUnityMessageFallback, which registers a receiver GameObject.
         public Task<PaywallResult> PresentPaywallAsync(PaywallOptions options)
         {
             if (s_current != null && !s_current.Task.IsCompleted)


### PR DESCRIPTION
## Summary

Implement iOS paywalls in RevenueCatUI with a pure-code callback path by default and an optional UnitySendMessage fallback. Keep core (RevenueCat) UI‑agnostic. Update Subtester to demo both modes.

RevenueCatUI 
      - Present paywall via PurchasesHybridCommonUI PaywallProxy (iOS 15+).
      - Strongly retain PaywallProxy during presentation to guarantee callback delivery.
      - Dual callback paths:
        - Primary: native delegate → completes Task<PaywallResult>. (Make pure-code the default for flexibility, with a GameObject-based fallback only when explicitly enabled)
        - Optional fallback: UnitySendMessage to a receiver (disabled by default).

