### PR TITLE
[v7] Prepare for next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,8 +396,14 @@ workflows:
 
   deploy:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        # Only run this workflow when the action is "build" (the default), 
+        # so it doesn't run for other actions like "bump" on a release branch,
+        # which should only open the release PR but not deploy it.
+        # (Deployment happens after the hold job is approved on the release PR.)
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
       - export-package: *release-tags
       - github-release:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 7d97553e9c5baabcd18286f03d8034797a27dd64
+  revision: 1593f78d0b9b24b48238337666183e3ba82f848e
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -224,7 +224,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0617)
+    mime-types-data (3.2025.0924)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.5)
@@ -236,11 +236,11 @@ GEM
     naturally (2.2.2)
     netrc (0.11.0)
     nkf (0.2.0)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-darwin)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (10.0.0)
       faraday (>= 1, < 3)

--- a/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
+++ b/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[14.2.0]" />
+        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[14.3.0]" />
         <androidPackage spec="androidx.annotation:annotation:[1.2.0]" />
     </androidPackages>
     <iosPods>
-        <iosPod name="PurchasesHybridCommon" version="14.2.0" minTargetSdk="13.0"/>
+        <iosPod name="PurchasesHybridCommon" version="14.3.0" minTargetSdk="13.0"/>
     </iosPods>
 </dependencies>

--- a/Subtester/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/mainTemplate.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
     implementation 'androidx.annotation:annotation:[1.2.0]' // Packages/com.revenuecat.purchases-unity/Plugins/Editor/RevenueCatDependencies.xml:5
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:[14.2.0]' // Packages/com.revenuecat.purchases-unity/Plugins/Editor/RevenueCatDependencies.xml:4
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:[14.3.0]' // Packages/com.revenuecat.purchases-unity/Plugins/Editor/RevenueCatDependencies.xml:4
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/Subtester/ProjectSettings/AndroidResolverDependencies.xml
+++ b/Subtester/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,7 +1,7 @@
 <dependencies>
   <packages>
     <package>androidx.annotation:annotation:[1.2.0]</package>
-    <package>com.revenuecat.purchases:purchases-hybrid-common:[14.2.0]</package>
+    <package>com.revenuecat.purchases:purchases-hybrid-common:[14.3.0]</package>
   </packages>
   <files />
   <settings>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,7 +57,8 @@ desc "Automatically bumps version, edit changelog, and create pull request"
 lane :automatic_bump do |options|
   next_version, type_of_bump = determine_next_version_using_labels(
     repo_name: repo_name,
-    github_rate_limit: options[:github_rate_limit]
+    github_rate_limit: options[:github_rate_limit],
+    current_version: current_version_number
   )
   options[:next_version] = next_version
   options[:automatic_release] = true


### PR DESCRIPTION
This PR makes the changes needed for the next release of v10.

* Bump [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `7d97553 ` to `1593f78`. See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/7d97553e9c5baabcd18286f03d8034797a27dd64...1593f78d0b9b24b48238337666183e3ba82f848e">compare view</a>.
* Pass current version in automatic bump.
* [CI] Only `build` pipeline action can trigger `on-release-branch` workflow.