### PR TITLE
Change default of `autoSyncPurchases` to `true` on runtime setups

### DIFF
--- a/RevenueCat/Scripts/PurchasesConfiguration.cs
+++ b/RevenueCat/Scripts/PurchasesConfiguration.cs
@@ -94,7 +94,7 @@ public partial class Purchases
 
             public PurchasesConfiguration Build()
             {
-                _dangerousSettings = _dangerousSettings ?? new DangerousSettings(false);
+                _dangerousSettings = _dangerousSettings ?? new DangerousSettings(true);
                 return new PurchasesConfiguration(_apiKey, _appUserId, _purchasesAreCompletedBy, _userDefaultsSuiteName,
                     _useAmazon, _dangerousSettings, _storeKitVersion, _shouldShowInAppMessagesAutomatically, 
                     _entitlementVerificationMode, _pendingTransactionsForPrepaidPlansEnabled);


### PR DESCRIPTION
We were wrongly setting `autoSyncPurchases` to `false` on runtime setups. The default is `true` in Android and in `RevenueCat.cs`