### PR TITLE
Remove direct `purchases` dependencies from RevenueCatUI gradle

### DIFF
--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
@@ -4,8 +4,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.revenuecat.purchases:purchases-hybrid-common:17.9.0'
     implementation 'com.revenuecat.purchases:purchases-hybrid-common-ui:17.9.0'
-    implementation 'com.revenuecat.purchases:purchases:9.8.0'
-    implementation 'com.revenuecat.purchases:purchases-ui:9.8.0'
     implementation 'androidx.activity:activity:1.8.2'
     // TODO: Automatically update this to the latest version
 }


### PR DESCRIPTION
This wasn't intended to be merged with #649 