### PR TITLE
Default DisplayCloseButton default set to false

### DIFF
--- a/RevenueCatUI/Scripts/Platforms/Android/AndroidPaywallPresenter.cs
+++ b/RevenueCatUI/Scripts/Platforms/Android/AndroidPaywallPresenter.cs
@@ -57,7 +57,7 @@ namespace RevenueCatUI.Platforms
             try
             {
                 var offering = options?.OfferingIdentifier;
-                var displayCloseButton = options?.DisplayCloseButton ?? true;
+                var displayCloseButton = options?.DisplayCloseButton ?? false;
                 
                 Debug.Log($"[RevenueCatUI][Android] presentPaywall offering='{offering ?? "<null>"}', displayCloseButton={displayCloseButton}");
                 var currentActivity = AndroidApplication.currentActivity;

--- a/RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs
+++ b/RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs
@@ -30,7 +30,7 @@ namespace RevenueCatUI.Platforms
             s_current = tcs;
             try
             {
-                rcui_presentPaywall(options?.OfferingIdentifier, options?.DisplayCloseButton ?? true, OnResult);
+                rcui_presentPaywall(options?.OfferingIdentifier, options?.DisplayCloseButton ?? false, OnResult);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
I checked purchases-android and purchases-ios and the default is false. Actually in the new `PaywallOptions` here in Unity we were already defaulting to `false`.

https://github.com/RevenueCat/purchases-android/blob/91c6034bb2b41d2183c5f84061a465a5b6002fcb/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt#L115