### PR TITLE
Fix automatic bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,13 +474,15 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "release-train", << pipeline.schedule.name >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          ruby_version: "3.2.0"
 
   manual-trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          ruby_version: "3.2.0"
 
   update-hybrid-common-versions:
     when:


### PR DESCRIPTION
It looks like automatic bumps fail I think due to the ruby and bundler versions being used. Updating to 3.2.0 fixes it 

https://app.circleci.com/pipelines/github/RevenueCat/purchases-unity/3145/workflows/bc76933e-fc84-44f2-a266-826f07f7a2fd/jobs/13802