### PR TITLE
Fix iOS compilation of RevenueCatUI when symlink sources enabled

### DIFF
--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib.meta
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib.meta
@@ -21,40 +21,40 @@ PluginImporter:
       enabled: 1
       settings:
         Exclude Android: 0
-        Exclude Editor: 0
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
-        Exclude WebGL: 0
-        Exclude Win: 0
-        Exclude Win64: 0
-        Exclude iOS: 0
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
     Editor:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
         OS: AnyOS
     Linux64:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86_64
     OSXUniversal:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
     WebGL:
-      enabled: 1
+      enabled: 0
       settings: {}
     Win:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86
     Win64:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
     iOS:
-      enabled: 1
+      enabled: 0
       settings:
         AddToEmbeddedBinaries: false
         CPU: AnyCPU


### PR DESCRIPTION
When building Android with Symlink sources is enabled, a `build` folder is created. After switching to iOS, when trying to export, I was getting failures because it was trying to build stuff in that `build` folder inside `.androidlib`.

I checked all platforms minus Android in the settings of the androidlib and it looks like that's fixed now

<img width="580" height="720" alt="image" src="https://github.com/user-attachments/assets/f6f7c22e-dae7-4fbd-a518-2d9ebb5347d2" />
