### PR TITLE
Enable releasing RevenueCatUI

### DIFF
--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     implementation 'com.revenuecat.purchases:purchases-hybrid-common:17.11.0'
     implementation 'com.revenuecat.purchases:purchases-hybrid-common-ui:17.11.0'
     implementation 'androidx.activity:activity:1.8.2'
-    // TODO: Automatically update this to the latest version
 }
 
 android {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,7 +95,7 @@ lane :github_release do |options|
     repo_name: repo_name,
     github_api_token: ENV["GITHUB_TOKEN"],
     changelog_latest_path: changelog_latest_path,
-    upload_assets: ['Purchases.unitypackage']
+    upload_assets: ['Purchases.unitypackage', 'PurchasesUI.unitypackage']
   )
 end
 


### PR DESCRIPTION
This will make sure the RevenueCatUI Unity package starts getting added to the releases