### PR TITLE
Add retry mechanism to Maestro e2e tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: ca2b191e4584a46a5fa9ad4b418af0f56a338cd3
+  revision: d1e580865d34d9a50c7429d0316a6e75f4873d9d
   branch: pallares/maestro-retry
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: d1e580865d34d9a50c7429d0316a6e75f4873d9d
-  branch: pallares/maestro-retry
+  revision: a1eed48467a057a8bbdac5a0587e3653a541a46b
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 6289be1dcdf7efc57682b284be9bdb1db3efbe69
+  revision: ca2b191e4584a46a5fa9ad4b418af0f56a338cd3
+  branch: pallares/maestro-retry
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -234,7 +235,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0331)
+    mime-types-data (3.2026.0414)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.27.0)
@@ -331,4 +332,4 @@ DEPENDENCIES
   fastlane-plugin-revenuecat_internal!
 
 BUNDLED WITH
-   2.7.2
+   2.7.1

--- a/e2e-tests/MaestroTestApp/Assets/Plugins/iOS/LaunchArgs.mm
+++ b/e2e-tests/MaestroTestApp/Assets/Plugins/iOS/LaunchArgs.mm
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+extern "C" {
+    const char* GetLaunchTestFlow() {
+        NSString* testFlow = [[NSUserDefaults standardUserDefaults] stringForKey:@"e2e_test_flow"];
+        if (testFlow == nil) return NULL;
+        const char* utf8 = [testFlow UTF8String];
+        char* result = (char*)malloc(strlen(utf8) + 1);
+        strcpy(result, utf8);
+        return result;
+    }
+}

--- a/e2e-tests/MaestroTestApp/Assets/Scripts/MaestroTestApp.cs
+++ b/e2e-tests/MaestroTestApp/Assets/Scripts/MaestroTestApp.cs
@@ -1,10 +1,23 @@
 using UnityEngine;
 using UnityEngine.UI;
 using RevenueCatUI;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 public class MaestroTestApp : Purchases.UpdatedCustomerInfoListener
 {
     private const string API_KEY = "MAESTRO_TESTS_REVENUECAT_API_KEY";
+
+#if UNITY_IOS && !UNITY_EDITOR
+    [DllImport("__Internal")]
+    private static extern string GetLaunchTestFlow();
+#endif
+
+    private static readonly Dictionary<string, System.Action<MaestroTestApp>> TestFlowScreenMap =
+        new Dictionary<string, System.Action<MaestroTestApp>>
+        {
+            { "purchase_through_paywall", app => app.ShowPurchaseScreen() }
+        };
 
     public GameObject testCasesScreen;
     public GameObject purchaseScreen;
@@ -28,7 +41,36 @@ public class MaestroTestApp : Purchases.UpdatedCustomerInfoListener
             errorLabel.gameObject.SetActive(false);
         }
 
-        ShowTestCases();
+        string testFlow = GetTestFlow();
+        if (testFlow != null && TestFlowScreenMap.TryGetValue(testFlow, out var navigateAction))
+        {
+            navigateAction(this);
+        }
+        else
+        {
+            ShowTestCases();
+        }
+    }
+
+    private string GetTestFlow()
+    {
+#if UNITY_IOS && !UNITY_EDITOR
+        return GetLaunchTestFlow();
+#elif UNITY_ANDROID && !UNITY_EDITOR
+        try
+        {
+            using var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+            using var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+            using var intent = activity.Call<AndroidJavaObject>("getIntent");
+            return intent.Call<string>("getStringExtra", "e2e_test_flow");
+        }
+        catch (System.Exception)
+        {
+            return null;
+        }
+#else
+        return null;
+#endif
     }
 
     public void ShowTestCases()

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -8,16 +8,12 @@ name: Purchase through paywall
 ---
 - clearState
 - pressKey: home
-- launchApp
-- extendedWaitUntil:
-    visible: "Test Cases"
-    timeout: 30000
-- assertVisible: "Test Cases"
-- tapOn:
-    text: "Purchase through paywall"
+- launchApp:
+    arguments:
+        e2e_test_flow: purchase_through_paywall
 - extendedWaitUntil:
     visible: "Entitlements: none"
-    timeout: 15000
+    timeout: 30000
 - assertVisible: "Entitlements: none"
 - assertVisible: "Present Paywall"
 - tapOn:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -176,8 +176,7 @@ lane :run_maestro_e2e_tests_ios do
   app_path = "#{derived_data_path}/Build/Products/Debug-iphonesimulator/MaestroTestApp.app"
   sh("xcrun simctl install booted '#{app_path}'")
 
-  sh("mkdir -p test_output")
-  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Run maestro E2E tests on Android"
@@ -214,8 +213,7 @@ lane :run_maestro_e2e_tests_android do
 
   sh("adb install '#{apk_path}'")
 
-  sh("mkdir -p test_output")
-  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Tag current branch with current version number"
@@ -225,6 +223,32 @@ lane :tag_current_branch do |options|
 
   add_git_tag(tag: version_number)
   push_git_tags(tag: version_number)
+end
+
+def run_maestro_with_retries(flow_dir:, output_dir:)
+  max_retries = 5
+  attempt = 0
+  success = false
+
+  FileUtils.mkdir_p(output_dir)
+
+  while attempt <= max_retries && !success
+    attempt_output_dir = "#{output_dir}/attempt_#{attempt}"
+    FileUtils.mkdir_p(attempt_output_dir)
+
+    begin
+      sh("maestro", "test", "--format", "junit", "--output", "#{attempt_output_dir}/report.xml", "--test-output-dir", attempt_output_dir, flow_dir)
+      success = true
+      FileUtils.cp("#{attempt_output_dir}/report.xml", "#{output_dir}/report.xml")
+    rescue => e
+      UI.error("Maestro test attempt #{attempt} failed: #{e.message}")
+      if attempt >= max_retries
+        raise e
+      end
+      attempt += 1
+      UI.message("Retrying... #{attempt}/#{max_retries}")
+    end
+  end
 end
 
 ###############################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -176,7 +176,7 @@ lane :run_maestro_e2e_tests_ios do
   app_path = "#{derived_data_path}/Build/Products/Debug-iphonesimulator/MaestroTestApp.app"
   sh("xcrun simctl install booted '#{app_path}'")
 
-  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
+  run_maestro_e2e_tests(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Run maestro E2E tests on Android"
@@ -213,7 +213,7 @@ lane :run_maestro_e2e_tests_android do
 
   sh("adb install '#{apk_path}'")
 
-  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
+  run_maestro_e2e_tests(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Tag current branch with current version number"
@@ -223,32 +223,6 @@ lane :tag_current_branch do |options|
 
   add_git_tag(tag: version_number)
   push_git_tags(tag: version_number)
-end
-
-def run_maestro_with_retries(flow_dir:, output_dir:)
-  max_retries = 5
-  attempt = 0
-  success = false
-
-  FileUtils.mkdir_p(output_dir)
-
-  while attempt <= max_retries && !success
-    attempt_output_dir = "#{output_dir}/attempt_#{attempt}"
-    FileUtils.mkdir_p(attempt_output_dir)
-
-    begin
-      sh("maestro", "test", "--format", "junit", "--output", "#{attempt_output_dir}/report.xml", "--test-output-dir", attempt_output_dir, flow_dir)
-      success = true
-      FileUtils.cp("#{attempt_output_dir}/report.xml", "#{output_dir}/report.xml")
-    rescue => e
-      UI.error("Maestro test attempt #{attempt} failed: #{e.message}")
-      if attempt >= max_retries
-        raise e
-      end
-      attempt += 1
-      UI.message("Retrying... #{attempt}/#{max_retries}")
-    end
-  end
 end
 
 ###############################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal"
+gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal", branch: "pallares/maestro-retry"

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal", branch: "pallares/maestro-retry"
+gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal"


### PR DESCRIPTION
## Summary
- Replaces inline retry logic with the shared `run_maestro_e2e_tests` action from `fastlane-plugin-revenuecat_internal`
- The plugin action handles up to 6 attempts with per-attempt output directories for debugging

## Test plan
- [ ] Verify Maestro e2e tests CI job runs successfully
- [ ] Confirm JUnit reports are correctly stored as artifacts