### PR TITLE
Remove update_fastlane from before_all

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,7 +48,6 @@ versions_path = './VERSIONS.md'
 
 before_all do
   setup_circle_ci
-  update_fastlane
 end
 
 desc "Bump version, edit changelog, and create pull request"


### PR DESCRIPTION
### Description

This was only caught by the two new (still-WIP) `run-maestro-e2e-tests-ios` / `run-maestro-e2e-tests-android` jobs being added in [#838](https://github.com/RevenueCat/purchases-unity/pull/838), which are the only jobs invoking lanes from the top-level `fastlane/Fastfile` (the existing `archive-ios` job uses `IntegrationTests/fastlane/Fastfile`, which already has `update_fastlane` commented out). They started failing today with:

```
Could not find fastlane-2.233.0 in locally installed gems
```

(see [failing job](https://app.circleci.com/pipelines/github/RevenueCat/purchases-unity/4019/workflows/1bb4e4ac-f6b1-47d9-b91e-eed316c4387d/jobs/20258)) after [fastlane 2.233.1](https://rubygems.org/gems/fastlane/versions/2.233.1) was released. The `update_fastlane` action in `before_all` calls `gem update fastlane` and then `gem cleanup` ([source](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/update_fastlane.rb)), which deletes the previous fastlane version. When fastlane restarts itself, `bundle exec` then fails to find the version pinned in `Gemfile.lock`.

`update_fastlane` is redundant when using Bundler (we already update fastlane through dependency PRs), so removing it from `before_all`.