### PR TITLE
fix(android): remove unused RevenueCatUI ProGuard config

### DIFF
--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
@@ -47,7 +47,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules. pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
@@ -35,7 +35,6 @@ android {
     def unityLib = project(':unityLibrary').extensions.getByName('android')
 
     defaultConfig {
-        consumerProguardFiles "consumer-proguard.pro"
         minSdkVersion unityLib.defaultConfig.minSdkVersion.mApiLevel
         targetSdkVersion unityLib.defaultConfig.targetSdkVersion.mApiLevel
     }

--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/consumer-proguard.pro
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/consumer-proguard.pro
@@ -1,0 +1,1 @@
+-keep class com.unity3d.player.** { *; }

--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/consumer-proguard.pro
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/consumer-proguard.pro
@@ -1,1 +1,0 @@
--keep class com.unity3d.player.** { *; }

--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/proguard-android-optimize.txt
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/proguard-android-optimize.txt
@@ -1,1 +1,0 @@
--keep class com.unity3d.player.** { *; }


### PR DESCRIPTION
## Motivation

`RevenueCatUI.androidlib/build.gradle` referenced `consumer-proguard.pro`, but the package did not ship that file. Newer Android Gradle Plugin versions fail when merging ProGuard files.

## Fix

Removed the unused `consumerProguardFiles` reference instead of adding a new consumer ProGuard file.

RevenueCatUI does not appear to need custom consumer ProGuard rules for Unity classes, and adding them would unnecessarily force downstream apps to keep `com.unity3d.player` classes unobfuscated. Also removed the old local `proguard-android-optimize.txt` file, which contained the same unnecessary rule.

Fixed the `proguard-rules.pro` filename typo while I was at it.

## Testing

Tested locally using a small validation script by Claude
