### PR TITLE
feat: Add SetAppsFlyerConversionData

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -193,6 +193,7 @@ public class PurchasesAPITests : MonoBehaviour
         purchases.SetAd("asdgas");
         purchases.SetKeyword("asdgas");
         purchases.SetCreative("asdgas");
+        purchases.SetAppsFlyerConversionData(new Dictionary<string, object>());
         purchases.CollectDeviceIdentifiers();
 
         bool receivedCanMakePayments = false;

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -535,6 +535,15 @@ public class PurchasesWrapper {
         SubscriberAttributesKt.setCreative(creative);
     }
 
+    public static void setAppsFlyerConversionData(String conversionDataJson) {
+        try {
+            JSONObject jsonObject = new JSONObject(conversionDataJson);
+            SubscriberAttributesKt.setAppsFlyerConversionData(MappersHelpersKt.convertToMap(jsonObject));
+        } catch (JSONException e) {
+            Log.e("Purchases", "Failure parsing conversion data " + conversionDataJson);
+        }
+    }
+
     public static void collectDeviceIdentifiers() {
         SubscriberAttributesKt.collectDeviceIdentifiers();
     }

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -442,6 +442,10 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     [RCCommonFunctionality setCreative:creative];
 }
 
+- (void)setAppsFlyerConversionData:(nullable NSDictionary *)data {
+    [RCCommonFunctionality setAppsFlyerConversionData:data];
+}
+
 - (void)showInAppMessages:(NSArray<NSNumber*>*)messageTypes {
     #if TARGET_OS_IPHONE
     if (@available(iOS 16.0, *)) {
@@ -1035,6 +1039,21 @@ void _RCSetKeyword(const char *keyword) {
 
 void _RCSetCreative(const char *creative) {
     [_RCUnityHelperShared() setCreative:convertCString(creative)];
+}
+
+void _RCSetAppsFlyerConversionData(const char *conversionDataJSON) {
+    NSError *error = nil;
+    NSData *conversionDataAsData = [convertCString(conversionDataJSON) dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *conversionData = [NSJSONSerialization JSONObjectWithData:conversionDataAsData
+                                                                  options:0
+                                                                    error:&error];
+
+    if (error) {
+        NSLog(@"Error parsing conversion data JSON: %s %@", conversionDataJSON, error.localizedDescription);
+        return;
+    }
+
+    [_RCUnityHelperShared() setAppsFlyerConversionData:conversionData];
 }
 
 void _RCCollectDeviceIdentifiers() {

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -1170,6 +1170,63 @@ public partial class Purchases : MonoBehaviour
 
     /**
      * <summary>
+     * Sets conversion data from AppsFlyer's onConversionDataSuccess callback. This method extracts
+     * the relevant attribution fields from the AppsFlyer conversion data and sets the corresponding
+     * RevenueCat subscriber attributes. Note that this method will never unset any attributes.
+     * </summary>
+     * <param name="conversionData">The conversion data from AppsFlyer's onConversionDataSuccess
+     * callback. Pass the result of <c>AppsFlyer.CallbackStringToDictionary(conversionData)</c>.</param>
+     */
+    public void SetAppsFlyerConversionData(Dictionary<string, object> conversionData)
+    {
+        var jsonObject = new JSONObject();
+        foreach (var keyValuePair in conversionData)
+        {
+            jsonObject[keyValuePair.Key] = ConvertToJsonNode(keyValuePair.Value);
+        }
+
+        _wrapper.SetAppsFlyerConversionData(jsonObject.ToString());
+    }
+
+    private static JSONNode ConvertToJsonNode(object value)
+    {
+        switch (value)
+        {
+            case null:
+                return JSONNull.CreateOrGet();
+            case string stringValue:
+                return stringValue;
+            case bool boolValue:
+                return boolValue;
+            case int intValue:
+                return intValue;
+            case long longValue:
+                return longValue;
+            case float floatValue:
+                return floatValue;
+            case double doubleValue:
+                return doubleValue;
+            case IDictionary<string, object> dictValue:
+                var nestedObject = new JSONObject();
+                foreach (var keyValuePair in dictValue)
+                {
+                    nestedObject[keyValuePair.Key] = ConvertToJsonNode(keyValuePair.Value);
+                }
+                return nestedObject;
+            case IEnumerable<object> listValue:
+                var nestedArray = new JSONArray();
+                foreach (var item in listValue)
+                {
+                    nestedArray.Add(ConvertToJsonNode(item));
+                }
+                return nestedArray;
+            default:
+                return value.ToString();
+        }
+    }
+
+    /**
+     * <summary>
      * Automatically collect subscriber attributes associated with the device identifiers.
      * $idfa, $idfv, $ip on iOS
      * $gpsAdId, $androidId, $ip on Android

--- a/RevenueCat/Scripts/PurchasesWrapper.cs
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs
@@ -76,6 +76,7 @@ public interface IPurchasesWrapper
     void SetAd(string ad);
     void SetKeyword(string keyword);
     void SetCreative(string creative);
+    void SetAppsFlyerConversionData(string conversionDataJson);
     void CollectDeviceIdentifiers();
     void CanMakePayments(Purchases.BillingFeature[] features);
     void GetPromotionalOffer(string productIdentifier, string discountIdentifier);

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -333,6 +333,11 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
         CallPurchases("setCreative", creative);
     }
 
+    public void SetAppsFlyerConversionData(string conversionDataJson)
+    {
+        CallPurchases("setAppsFlyerConversionData", conversionDataJson);
+    }
+
     public void CollectDeviceIdentifiers()
     {
         CallPurchases("collectDeviceIdentifiers");

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs
@@ -232,6 +232,10 @@ public partial class Purchases
         {
         }
 
+        public void SetAppsFlyerConversionData(string conversionDataJson)
+        {
+        }
+
         public void CollectDeviceIdentifiers()
         {
         }

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -409,6 +409,13 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     }
 
     [DllImport("__Internal")]
+    private static extern void _RCSetAppsFlyerConversionData(string conversionDataJson);
+    public void SetAppsFlyerConversionData(string conversionDataJson)
+    {
+        _RCSetAppsFlyerConversionData(conversionDataJson);
+    }
+
+    [DllImport("__Internal")]
     private static extern void _RCCollectDeviceIdentifiers();
     public void CollectDeviceIdentifiers()
     {

--- a/Subtester/Assets/Tester/Scripts/Screens/AttributesScreen.cs
+++ b/Subtester/Assets/Tester/Scripts/Screens/AttributesScreen.cs
@@ -85,6 +85,25 @@ namespace RevenueCat.Tester.Screens
                 LogSuccess($"Phone number set to \"{phoneField.value}\"");
             });
 
+            AddSectionHeader("AppsFlyer");
+
+            AddButton("Set AppsFlyer Conversion Data", () =>
+            {
+                var conversionData = new Dictionary<string, object>
+                {
+                    { "af_status", "Non-organic" },
+                    { "media_source", "test_media_source" },
+                    { "campaign", "test_campaign" },
+                    { "adgroup", "test_adgroup" },
+                    { "af_ad", "test_ad" },
+                    { "af_keywords", "test_keyword" },
+                    { "creative", "test_creative" },
+                    { "is_first_launch", true },
+                };
+                Purchases.SetAppsFlyerConversionData(conversionData);
+                LogSuccess("AppsFlyer conversion data set");
+            });
+
             AddSectionHeader("Device");
 
             AddButton("Collect Device Identifiers", () =>


### PR DESCRIPTION
Adds `Purchases.SetAppsFlyerConversionData(Dictionary<string, object> conversionData)`. Apps pass the conversion data from AppsFlyer's `onConversionDataSuccess` callback, and the SDK forwards it to RevenueCat, which maps it onto the corresponding subscriber attributes.

```csharp
public void onConversionDataSuccess(string conversionData) {
  var data = AppsFlyer.CallbackStringToDictionary(conversionData);
  purchases.SetAppsFlyerConversionData(data);
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive subscriber-attribute API following existing setter patterns; malformed JSON is logged and dropped without affecting purchases or auth.
> 
> **Overview**
> Adds **`Purchases.SetAppsFlyerConversionData(Dictionary<string, object>)`** so Unity apps can pass AppsFlyer **`onConversionDataSuccess`** payloads into RevenueCat; the native SDK maps fields to install attribution subscriber attributes and **does not unset** existing attributes.
> 
> The public API serializes the dictionary to JSON (including nested dicts/lists via a new **`ConvertToJsonNode`** helper), then routes through **`IPurchasesWrapper`** on **iOS** (JSON parse → **`RCCommonFunctionality`**) and **Android** (JSON → map → **`SubscriberAttributesKt`**), with a **noop** editor stub. **API tests** and **Subtester** gain coverage/manual trigger for the new call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bfa5728ff82d7abf17a6db10d3058d8656b1bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->