### PR TITLE
Add presentedOfferingContext support to custom paywall impression events

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -249,10 +249,6 @@ public class PurchasesAPITests : MonoBehaviour
         Purchases.Offering offering = CreateOfferingForCustomPaywallImpression();
         purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(offering));
         purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(offering, "my_custom_paywall"));
-        purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(
-            offering,
-            "my_custom_paywall",
-            "ignored_offering_id"));
 
         // Ad tracking API tests
         purchases.AdTracker.TrackAdDisplayed(new AdDisplayedData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "ad_unit", "imp_001"));

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -247,8 +247,11 @@ public class PurchasesAPITests : MonoBehaviour
         purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams("my_custom_paywall", "offering_id"));
 #pragma warning restore CS0618
         Purchases.Offering offering = CreateOfferingForCustomPaywallImpression();
-        purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(offering));
-        purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(offering, "my_custom_paywall"));
+        Purchases.CustomPaywallImpressionParams paramsWithOffering =
+            new Purchases.CustomPaywallImpressionParams(offering);
+        Purchases.Offering paramsOffering = paramsWithOffering.Offering;
+        purchases.TrackCustomPaywallImpression(paramsWithOffering);
+        purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams("my_custom_paywall", paramsOffering));
 
         // Ad tracking API tests
         purchases.AdTracker.TrackAdDisplayed(new AdDisplayedData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "ad_unit", "imp_001"));

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using RevenueCat;
+using RevenueCat.SimpleJSON;
 
 public class CustomListener : Purchases.UpdatedCustomerInfoListener
 {
@@ -239,8 +240,19 @@ public class PurchasesAPITests : MonoBehaviour
 
         purchases.TrackCustomPaywallImpression();
         purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams("my_custom_paywall"));
+#pragma warning disable CS0618
+        purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams(paywallId: null, offeringId: null));
+        purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams(paywallId: "", offeringId: ""));
         purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams(offeringId: "offering_id"));
         purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams("my_custom_paywall", "offering_id"));
+#pragma warning restore CS0618
+        Purchases.Offering offering = CreateOfferingForCustomPaywallImpression();
+        purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(offering));
+        purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(offering, "my_custom_paywall"));
+        purchases.TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams.FromOffering(
+            offering,
+            "my_custom_paywall",
+            "ignored_offering_id"));
 
         // Ad tracking API tests
         purchases.AdTracker.TrackAdDisplayed(new AdDisplayedData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "ad_unit", "imp_001"));
@@ -289,5 +301,40 @@ public class PurchasesAPITests : MonoBehaviour
 
         receivedVirtualCurrencies = purchases.GetCachedVirtualCurrencies();
         purchases.InvalidateVirtualCurrenciesCache();
+    }
+
+    private static Purchases.Offering CreateOfferingForCustomPaywallImpression()
+    {
+        JSONNode offeringJson = JSON.Parse(
+            @"{
+                ""identifier"": ""custom_offering"",
+                ""serverDescription"": ""Custom paywall offering"",
+                ""metadata"": {},
+                ""availablePackages"": [
+                    {
+                        ""identifier"": ""$rc_monthly"",
+                        ""packageType"": ""MONTHLY"",
+                        ""product"": {
+                            ""identifier"": ""product_id"",
+                            ""title"": ""Monthly"",
+                            ""description"": ""Monthly subscription"",
+                            ""price"": 1.99,
+                            ""priceString"": ""$1.99"",
+                            ""currencyCode"": ""USD"",
+                            ""productCategory"": ""SUBSCRIPTION""
+                        },
+                        ""presentedOfferingContext"": {
+                            ""offeringIdentifier"": ""custom_offering"",
+                            ""placementIdentifier"": ""onboarding"",
+                            ""targetingContext"": {
+                                ""revision"": 7,
+                                ""ruleId"": ""rule_1""
+                            }
+                        }
+                    }
+                ]
+            }");
+
+        return new Purchases.Offering(offeringJson);
     }
 }

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -737,8 +737,11 @@ public class PurchasesWrapper {
         if (presentedOfferingContextJSON != null && !presentedOfferingContextJSON.isEmpty()) {
             try {
                 JSONObject presentedOfferingContextJSONObject = new JSONObject(presentedOfferingContextJSON);
-                data.put("presentedOfferingContext",
-                        mapWithoutNullValues(MappersHelpersKt.convertToMap(presentedOfferingContextJSONObject)));
+                Object presentedOfferingContext = valueWithoutNullValues(
+                        MappersHelpersKt.convertToMap(presentedOfferingContextJSONObject));
+                if (presentedOfferingContext != null) {
+                    data.put("presentedOfferingContext", presentedOfferingContext);
+                }
             } catch (JSONException e) {
                 logJSONException(e);
             }
@@ -746,13 +749,13 @@ public class PurchasesWrapper {
         CommonKt.trackCustomPaywallImpression(mapWithoutNullValues(data));
     }
 
-    private static HashMap<String, Object> mapWithoutNullValues(@Nullable Map<?, ?> map) {
+    private static HashMap<String, Object> mapWithoutNullValues(@Nullable Map<String, Object> map) {
         HashMap<String, Object> filteredMap = new HashMap<>();
         if (map != null) {
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
                 Object value = valueWithoutNullValues(entry.getValue());
-                if (entry.getKey() instanceof String && value != null) {
-                    filteredMap.put((String) entry.getKey(), value);
+                if (value != null) {
+                    filteredMap.put(entry.getKey(), value);
                 }
             }
         }
@@ -760,11 +763,16 @@ public class PurchasesWrapper {
     }
 
     private static Object valueWithoutNullValues(@Nullable Object value) {
-        if (value == null || value == JSONObject.NULL) {
-            return null;
-        }
         if (value instanceof Map) {
-            return mapWithoutNullValues((Map<?, ?>) value);
+            HashMap<String, Object> filteredMap = new HashMap<>();
+            Map<?, ?> originalMap = (Map<?, ?>) value;
+            for (Map.Entry<?, ?> entry : originalMap.entrySet()) {
+                Object filteredValue = valueWithoutNullValues(entry.getValue());
+                if (entry.getKey() instanceof String && filteredValue != null) {
+                    filteredMap.put((String) entry.getKey(), filteredValue);
+                }
+            }
+            return filteredMap;
         }
         if (value instanceof List) {
             ArrayList<Object> filteredList = new ArrayList<>();

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -719,6 +719,14 @@ public class PurchasesWrapper {
     }
 
     public static void trackCustomPaywallImpression(@Nullable String paywallId, @Nullable String offeringId) {
+        trackCustomPaywallImpression(paywallId, offeringId, null);
+    }
+
+    public static void trackCustomPaywallImpression(
+            @Nullable String paywallId,
+            @Nullable String offeringId,
+            @Nullable String presentedOfferingContextJSON
+    ) {
         Map<String, Object> data = new HashMap<>();
         if (paywallId != null) {
             data.put("paywallId", paywallId);
@@ -726,7 +734,49 @@ public class PurchasesWrapper {
         if (offeringId != null) {
             data.put("offeringId", offeringId);
         }
-        CommonKt.trackCustomPaywallImpression(data);
+        if (presentedOfferingContextJSON != null && !presentedOfferingContextJSON.isEmpty()) {
+            try {
+                JSONObject presentedOfferingContextJSONObject = new JSONObject(presentedOfferingContextJSON);
+                data.put("presentedOfferingContext",
+                        mapWithoutNullValues(MappersHelpersKt.convertToMap(presentedOfferingContextJSONObject)));
+            } catch (JSONException e) {
+                logJSONException(e);
+            }
+        }
+        CommonKt.trackCustomPaywallImpression(mapWithoutNullValues(data));
+    }
+
+    private static HashMap<String, Object> mapWithoutNullValues(@Nullable Map<?, ?> map) {
+        HashMap<String, Object> filteredMap = new HashMap<>();
+        if (map != null) {
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object value = valueWithoutNullValues(entry.getValue());
+                if (entry.getKey() instanceof String && value != null) {
+                    filteredMap.put((String) entry.getKey(), value);
+                }
+            }
+        }
+        return filteredMap;
+    }
+
+    private static Object valueWithoutNullValues(@Nullable Object value) {
+        if (value == null || value == JSONObject.NULL) {
+            return null;
+        }
+        if (value instanceof Map) {
+            return mapWithoutNullValues((Map<?, ?>) value);
+        }
+        if (value instanceof List) {
+            ArrayList<Object> filteredList = new ArrayList<>();
+            for (Object item : (List<?>) value) {
+                Object filteredItem = valueWithoutNullValues(item);
+                if (filteredItem != null) {
+                    filteredList.add(filteredItem);
+                }
+            }
+            return filteredList;
+        }
+        return value;
     }
 
     public static void trackAdDisplayed(String dataJson) {

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -580,8 +580,8 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 }
 
 - (void)trackCustomPaywallImpression:(nullable NSString *)paywallId
-                           offeringId:(nullable NSString *)offeringId
-             presentedOfferingContext:(nullable NSString *)presentedOfferingContextJson {
+                            offeringId:(nullable NSString *)offeringId
+              presentedOfferingContext:(nullable NSString *)presentedOfferingContextJson {
     NSMutableDictionary *data = [NSMutableDictionary dictionary];
     if (paywallId) {
         data[@"paywallId"] = paywallId;

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -10,6 +10,12 @@
 @import PurchasesHybridCommon;
 @import RevenueCat;
 
+@interface NSObject (NSNullMapping)
+
+- (id)mappingNSNullToNil;
+
+@end
+
 static NSString *const RECEIVE_STOREFRONT = @"_receiveStorefront";
 static NSString *const RECEIVE_PRODUCTS = @"_receiveProducts";
 static NSString *const RECEIVE_CUSTOMER_INFO = @"_receiveCustomerInfo";
@@ -56,38 +62,6 @@ char *makeStringCopy(NSString *nstring) {
     strcpy(res, string);
 
     return res;
-}
-
-static id valueByRemovingNSNull(id value) {
-    if (!value || value == (id)[NSNull null]) {
-        return nil;
-    }
-
-    if ([value isKindOfClass:NSDictionary.class]) {
-        NSMutableDictionary *filteredDictionary = [NSMutableDictionary dictionary];
-        NSDictionary *dictionary = (NSDictionary *) value;
-        for (id key in dictionary) {
-            id filteredValue = valueByRemovingNSNull(dictionary[key]);
-            if (filteredValue) {
-                filteredDictionary[key] = filteredValue;
-            }
-        }
-        return [NSDictionary dictionaryWithDictionary:filteredDictionary];
-    }
-
-    if ([value isKindOfClass:NSArray.class]) {
-        NSMutableArray *filteredArray = [NSMutableArray array];
-        NSArray *array = (NSArray *) value;
-        for (id item in array) {
-            id filteredItem = valueByRemovingNSNull(item);
-            if (filteredItem) {
-                [filteredArray addObject:filteredItem];
-            }
-        }
-        return [NSArray arrayWithArray:filteredArray];
-    }
-
-    return value;
 }
 
 #pragma mark RCPurchases Wrapper
@@ -622,13 +596,13 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
         if (error) {
             NSLog(@"Error parsing presentedOfferingContext JSON: %@ %@", presentedOfferingContextJson, error.localizedDescription);
         } else if (presentedOfferingContext) {
-            id filteredPresentedOfferingContext = valueByRemovingNSNull(presentedOfferingContext);
+            id filteredPresentedOfferingContext = [presentedOfferingContext mappingNSNullToNil];
             if (filteredPresentedOfferingContext) {
                 data[@"presentedOfferingContext"] = filteredPresentedOfferingContext;
             }
         }
     }
-    [RCCommonFunctionality trackCustomPaywallImpression:valueByRemovingNSNull(data)];
+    [RCCommonFunctionality trackCustomPaywallImpression:data.mappingNSNullToNil ?: @{}];
 }
 
 - (void)trackAdDisplayed:(NSString *)dataJson {
@@ -1214,3 +1188,42 @@ void _RCTrackAdLoaded(const char *dataJson) {
 void _RCTrackAdFailedToLoad(const char *dataJson) {
     [_RCUnityHelperShared() trackAdFailedToLoad:convertCString(dataJson)];
 }
+
+@implementation NSObject (NSNullMapping)
+
+- (id)mappingNSNullToNil {
+    if ([self isKindOfClass:[NSNull class]]) {
+        return nil;
+    } else if ([self isKindOfClass:NSDictionary.class]) {
+        NSMutableDictionary *filteredDict = [NSMutableDictionary dictionary];
+        NSDictionary *originalDict = (NSDictionary *)self;
+
+        for (id key in originalDict) {
+            id value = [originalDict[key] mappingNSNullToNil];
+            if (value) {
+                // Only add non-nil values to the dictionary
+                filteredDict[key] = value;
+            }
+        }
+
+        return [NSDictionary dictionaryWithDictionary:filteredDict];
+
+    } else if ([self isKindOfClass:NSArray.class]) {
+        NSMutableArray *filteredArray = [NSMutableArray array];
+        NSArray *originalArray = (NSArray *)self;
+
+        for (id value in originalArray) {
+            id newValue = [value mappingNSNullToNil];
+            if (newValue) {
+                // Only add non-nil values to the array
+                [filteredArray addObject:newValue];
+            }
+        }
+
+        return [NSArray arrayWithArray:filteredArray];
+    }
+
+    return self;
+}
+
+@end

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -580,8 +580,8 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 }
 
 - (void)trackCustomPaywallImpression:(nullable NSString *)paywallId
-                            offeringId:(nullable NSString *)offeringId
-              presentedOfferingContext:(nullable NSString *)presentedOfferingContextJson {
+                          offeringId:(nullable NSString *)offeringId
+            presentedOfferingContext:(nullable NSString *)presentedOfferingContextJson {
     NSMutableDictionary *data = [NSMutableDictionary dictionary];
     if (paywallId) {
         data[@"paywallId"] = paywallId;

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -58,6 +58,38 @@ char *makeStringCopy(NSString *nstring) {
     return res;
 }
 
+static id valueByRemovingNSNull(id value) {
+    if (!value || value == (id)[NSNull null]) {
+        return nil;
+    }
+
+    if ([value isKindOfClass:NSDictionary.class]) {
+        NSMutableDictionary *filteredDictionary = [NSMutableDictionary dictionary];
+        NSDictionary *dictionary = (NSDictionary *) value;
+        for (id key in dictionary) {
+            id filteredValue = valueByRemovingNSNull(dictionary[key]);
+            if (filteredValue) {
+                filteredDictionary[key] = filteredValue;
+            }
+        }
+        return [NSDictionary dictionaryWithDictionary:filteredDictionary];
+    }
+
+    if ([value isKindOfClass:NSArray.class]) {
+        NSMutableArray *filteredArray = [NSMutableArray array];
+        NSArray *array = (NSArray *) value;
+        for (id item in array) {
+            id filteredItem = valueByRemovingNSNull(item);
+            if (filteredItem) {
+                [filteredArray addObject:filteredItem];
+            }
+        }
+        return [NSArray arrayWithArray:filteredArray];
+    }
+
+    return value;
+}
+
 #pragma mark RCPurchases Wrapper
 
 @interface RCUnityHelperDelegate : NSObject <RCPurchasesDelegate>
@@ -573,7 +605,9 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     }];
 }
 
-- (void)trackCustomPaywallImpression:(nullable NSString *)paywallId offeringId:(nullable NSString *)offeringId {
+- (void)trackCustomPaywallImpression:(nullable NSString *)paywallId
+                           offeringId:(nullable NSString *)offeringId
+             presentedOfferingContext:(nullable NSString *)presentedOfferingContextJson {
     NSMutableDictionary *data = [NSMutableDictionary dictionary];
     if (paywallId) {
         data[@"paywallId"] = paywallId;
@@ -581,7 +615,20 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     if (offeringId) {
         data[@"offeringId"] = offeringId;
     }
-    [RCCommonFunctionality trackCustomPaywallImpression:data];
+    if (presentedOfferingContextJson.length > 0) {
+        NSError *error = nil;
+        NSData *jsonData = [presentedOfferingContextJson dataUsingEncoding:NSUTF8StringEncoding];
+        id presentedOfferingContext = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+        if (error) {
+            NSLog(@"Error parsing presentedOfferingContext JSON: %@ %@", presentedOfferingContextJson, error.localizedDescription);
+        } else if (presentedOfferingContext) {
+            id filteredPresentedOfferingContext = valueByRemovingNSNull(presentedOfferingContext);
+            if (filteredPresentedOfferingContext) {
+                data[@"presentedOfferingContext"] = filteredPresentedOfferingContext;
+            }
+        }
+    }
+    [RCCommonFunctionality trackCustomPaywallImpression:valueByRemovingNSNull(data)];
 }
 
 - (void)trackAdDisplayed:(NSString *)dataJson {
@@ -1142,8 +1189,10 @@ void _RCPurchasePackageWithWinBackOffer(const char *packageIdentifier, const cha
     [_RCUnityHelperShared() purchasePackageWithWinBackOffer:packageIdentifierString presentedOfferingContextJson:presentedOfferingContextJsonString winBackOfferIdentifier:winBackOfferIdentifierString];
 }
 
-void _RCTrackCustomPaywallImpression(const char *paywallId, const char *offeringId) {
-    [_RCUnityHelperShared() trackCustomPaywallImpression:convertCString(paywallId) offeringId:convertCString(offeringId)];
+void _RCTrackCustomPaywallImpression(const char *paywallId, const char *offeringId, const char *presentedOfferingContextJson) {
+    [_RCUnityHelperShared() trackCustomPaywallImpression:convertCString(paywallId)
+                                              offeringId:convertCString(offeringId)
+                                presentedOfferingContext:convertCString(presentedOfferingContextJson)];
 }
 
 void _RCTrackAdDisplayed(const char *dataJson) {

--- a/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
+++ b/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
@@ -1,3 +1,5 @@
+using System;
+
 public partial class Purchases
 {
     /// <summary>
@@ -12,20 +14,79 @@ public partial class Purchases
 
         /// <summary>
         /// An optional identifier for the offering associated with the custom paywall.
-        /// If not provided, the SDK will use the current offering identifier from the cache.
+        /// If neither this nor an Offering is provided, no offering data is sent and the
+        /// native SDK handles its default fallback behavior.
+        /// Deprecated: use FromOffering instead so the SDK can derive placement and targeting context.
         /// </summary>
+        [Obsolete("Use FromOffering instead.", false)]
         public string OfferingId { get; private set; }
+
+        internal PresentedOfferingContext PresentedOfferingContext { get; private set; }
+
+        /// <summary>
+        /// Creates parameters for a custom paywall impression.
+        /// </summary>
+        public CustomPaywallImpressionParams()
+        {
+            SetValues(null, null, null);
+        }
+
+        /// <summary>
+        /// Creates parameters for a custom paywall impression.
+        /// </summary>
+        /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
+        public CustomPaywallImpressionParams(string paywallId)
+        {
+            SetValues(paywallId, null, null);
+        }
 
         /// <summary>
         /// Creates parameters for a custom paywall impression.
         /// </summary>
         /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
         /// <param name="offeringId">An optional identifier for the offering associated with the custom paywall.
-        /// If not provided, the SDK will use the current offering identifier from the cache.</param>
+        /// If neither this nor an Offering is provided, no offering data is sent and the native SDK
+        /// handles its default fallback behavior.
+        /// Deprecated: use FromOffering instead so the SDK can derive placement and targeting context.</param>
+        [Obsolete("Use FromOffering instead.", false)]
         public CustomPaywallImpressionParams(string paywallId = null, string offeringId = null)
         {
+            SetValues(paywallId, offeringId, null);
+        }
+
+        /// <summary>
+        /// Creates parameters for a custom paywall impression from an Offering.
+        /// </summary>
+        /// <param name="offering">An optional offering associated with the custom paywall. When provided,
+        /// the SDK derives the offering identifier and presented offering context from this offering's first
+        /// available package.</param>
+        /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
+        /// <param name="offeringId">Deprecated. This value is ignored when an Offering is provided.</param>
+        public static CustomPaywallImpressionParams FromOffering(Offering offering, string paywallId = null, string offeringId = null)
+        {
+            return new CustomPaywallImpressionParams(paywallId, offeringId, offering);
+        }
+
+        private CustomPaywallImpressionParams(string paywallId, string offeringId, Offering offering)
+        {
+            SetValues(paywallId, offeringId, offering);
+        }
+
+        private void SetValues(string paywallId, string offeringId, Offering offering)
+        {
             PaywallId = paywallId;
-            OfferingId = offeringId;
+#pragma warning disable CS0618
+            var resolvedOfferingId = offering != null ? offering.Identifier : offeringId;
+            OfferingId = resolvedOfferingId;
+#pragma warning restore CS0618
+            PresentedOfferingContext = GetPresentedOfferingContext(offering);
+        }
+
+        private static PresentedOfferingContext GetPresentedOfferingContext(Offering offering)
+        {
+            return offering != null && offering.AvailablePackages != null && offering.AvailablePackages.Count > 0
+                ? offering.AvailablePackages[0].PresentedOfferingContext
+                : null;
         }
     }
 }

--- a/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
+++ b/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
@@ -19,12 +19,7 @@ public partial class Purchases
         /// </summary>
         public string OfferingId { get; private set; }
 
-        private PresentedOfferingContext _presentedOfferingContext;
-
-        internal string PresentedOfferingContextJson
-        {
-            get { return _presentedOfferingContext?.ToJsonString(); }
-        }
+        internal PresentedOfferingContext PresentedOfferingContext { get; private set; }
 
         /// <summary>
         /// Creates parameters for a custom paywall impression.
@@ -79,7 +74,7 @@ public partial class Purchases
             PaywallId = paywallId;
             var resolvedOfferingId = offering != null ? offering.Identifier : offeringId;
             OfferingId = resolvedOfferingId;
-            _presentedOfferingContext = GetPresentedOfferingContext(offering);
+            PresentedOfferingContext = GetPresentedOfferingContext(offering);
         }
 
         private static PresentedOfferingContext GetPresentedOfferingContext(Offering offering)

--- a/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
+++ b/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
@@ -19,7 +19,12 @@ public partial class Purchases
         /// </summary>
         public string OfferingId { get; private set; }
 
-        internal PresentedOfferingContext PresentedOfferingContext { get; private set; }
+        private PresentedOfferingContext _presentedOfferingContext;
+
+        internal string PresentedOfferingContextJson
+        {
+            get { return _presentedOfferingContext?.ToJsonString(); }
+        }
 
         /// <summary>
         /// Creates parameters for a custom paywall impression.
@@ -74,7 +79,7 @@ public partial class Purchases
             PaywallId = paywallId;
             var resolvedOfferingId = offering != null ? offering.Identifier : offeringId;
             OfferingId = resolvedOfferingId;
-            PresentedOfferingContext = GetPresentedOfferingContext(offering);
+            _presentedOfferingContext = GetPresentedOfferingContext(offering);
         }
 
         private static PresentedOfferingContext GetPresentedOfferingContext(Offering offering)

--- a/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
+++ b/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
@@ -16,9 +16,7 @@ public partial class Purchases
         /// An optional identifier for the offering associated with the custom paywall.
         /// If neither this nor an Offering is provided, no offering data is sent and the
         /// native SDK handles its default fallback behavior.
-        /// Deprecated: use FromOffering instead so the SDK can derive placement and targeting context.
         /// </summary>
-        [Obsolete("Use FromOffering instead.", false)]
         public string OfferingId { get; private set; }
 
         internal PresentedOfferingContext PresentedOfferingContext { get; private set; }
@@ -61,10 +59,9 @@ public partial class Purchases
         /// the SDK derives the offering identifier and presented offering context from this offering's first
         /// available package.</param>
         /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
-        /// <param name="offeringId">Deprecated. This value is ignored when an Offering is provided.</param>
-        public static CustomPaywallImpressionParams FromOffering(Offering offering, string paywallId = null, string offeringId = null)
+        public static CustomPaywallImpressionParams FromOffering(Offering offering, string paywallId = null)
         {
-            return new CustomPaywallImpressionParams(paywallId, offeringId, offering);
+            return new CustomPaywallImpressionParams(paywallId, null, offering);
         }
 
         private CustomPaywallImpressionParams(string paywallId, string offeringId, Offering offering)
@@ -75,10 +72,8 @@ public partial class Purchases
         private void SetValues(string paywallId, string offeringId, Offering offering)
         {
             PaywallId = paywallId;
-#pragma warning disable CS0618
             var resolvedOfferingId = offering != null ? offering.Identifier : offeringId;
             OfferingId = resolvedOfferingId;
-#pragma warning restore CS0618
             PresentedOfferingContext = GetPresentedOfferingContext(offering);
         }
 

--- a/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
+++ b/RevenueCat/Scripts/CustomPaywallImpressionParams.cs
@@ -14,12 +14,24 @@ public partial class Purchases
 
         /// <summary>
         /// An optional identifier for the offering associated with the custom paywall.
-        /// If neither this nor an Offering is provided, no offering data is sent and the
-        /// native SDK handles its default fallback behavior.
+        /// Deprecated: use the Offering object instead so the SDK can derive placement and targeting context.
         /// </summary>
         public string OfferingId { get; private set; }
 
-        internal PresentedOfferingContext PresentedOfferingContext { get; private set; }
+        /// <summary>
+        /// The offering associated with the custom paywall, if provided.
+        /// </summary>
+        public Offering Offering { get; private set; }
+
+        internal PresentedOfferingContext PresentedOfferingContext
+        {
+            get
+            {
+                return Offering != null && Offering.AvailablePackages != null && Offering.AvailablePackages.Count > 0
+                    ? Offering.AvailablePackages[0].PresentedOfferingContext
+                    : null;
+            }
+        }
 
         /// <summary>
         /// Creates parameters for a custom paywall impression.
@@ -39,29 +51,36 @@ public partial class Purchases
         }
 
         /// <summary>
-        /// Creates parameters for a custom paywall impression.
+        /// Creates parameters for a custom paywall impression from an offering.
+        /// The SDK derives the offering identifier and presented offering context from this offering.
         /// </summary>
-        /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
-        /// <param name="offeringId">An optional identifier for the offering associated with the custom paywall.
-        /// If neither this nor an Offering is provided, no offering data is sent and the native SDK
-        /// handles its default fallback behavior.
-        /// Deprecated: use FromOffering instead so the SDK can derive placement and targeting context.</param>
-        [Obsolete("Use FromOffering instead.", false)]
-        public CustomPaywallImpressionParams(string paywallId = null, string offeringId = null)
+        /// <param name="offering">The offering associated with the custom paywall.</param>
+        public CustomPaywallImpressionParams(Offering offering)
         {
-            SetValues(paywallId, offeringId, null);
+            SetValues(null, null, offering);
         }
 
         /// <summary>
-        /// Creates parameters for a custom paywall impression from an Offering.
+        /// Creates parameters for a custom paywall impression from an offering.
+        /// The SDK derives the offering identifier and presented offering context from this offering.
         /// </summary>
-        /// <param name="offering">An optional offering associated with the custom paywall. When provided,
-        /// the SDK derives the offering identifier and presented offering context from this offering's first
-        /// available package.</param>
         /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
-        public static CustomPaywallImpressionParams FromOffering(Offering offering, string paywallId = null)
+        /// <param name="offering">The offering associated with the custom paywall.</param>
+        public CustomPaywallImpressionParams(string paywallId, Offering offering)
         {
-            return new CustomPaywallImpressionParams(paywallId, null, offering);
+            SetValues(paywallId, null, offering);
+        }
+
+        /// <summary>
+        /// Creates parameters for a custom paywall impression with an offering identifier string.
+        /// </summary>
+        /// <param name="paywallId">An optional identifier for the custom paywall being shown.</param>
+        /// <param name="offeringId">An optional identifier for the offering associated with the custom paywall.
+        /// Deprecated: pass an Offering instead so the SDK can derive placement and targeting context.</param>
+        [Obsolete("Pass an Offering instead.", false)]
+        public CustomPaywallImpressionParams(string paywallId = null, string offeringId = null)
+        {
+            SetValues(paywallId, offeringId, null);
         }
 
         private CustomPaywallImpressionParams(string paywallId, string offeringId, Offering offering)
@@ -72,16 +91,9 @@ public partial class Purchases
         private void SetValues(string paywallId, string offeringId, Offering offering)
         {
             PaywallId = paywallId;
+            Offering = offering;
             var resolvedOfferingId = offering != null ? offering.Identifier : offeringId;
             OfferingId = resolvedOfferingId;
-            PresentedOfferingContext = GetPresentedOfferingContext(offering);
-        }
-
-        private static PresentedOfferingContext GetPresentedOfferingContext(Offering offering)
-        {
-            return offering != null && offering.AvailablePackages != null && offering.AvailablePackages.Count > 0
-                ? offering.AvailablePackages[0].PresentedOfferingContext
-                : null;
         }
     }
 }

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -1358,7 +1358,7 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     public void TrackCustomPaywallImpression()
     {
-        _wrapper.TrackCustomPaywallImpression(new CustomPaywallImpressionParams());
+        TrackCustomPaywallImpression(new CustomPaywallImpressionParams());
     }
 
     public delegate void ParseAsWebPurchaseRedemptionFunc(WebPurchaseRedemption webPurchaseRedemption);

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -1358,7 +1358,7 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     public void TrackCustomPaywallImpression()
     {
-        TrackCustomPaywallImpression(new CustomPaywallImpressionParams());
+        _wrapper.TrackCustomPaywallImpression(new CustomPaywallImpressionParams());
     }
 
     public delegate void ParseAsWebPurchaseRedemptionFunc(WebPurchaseRedemption webPurchaseRedemption);

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -438,7 +438,11 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
 
     public void TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams parameters)
     {
-        CallPurchases("trackCustomPaywallImpression", parameters.PaywallId, parameters.OfferingId);
+#pragma warning disable CS0618
+        var offeringId = parameters.OfferingId;
+#pragma warning restore CS0618
+        CallPurchases("trackCustomPaywallImpression", parameters.PaywallId, offeringId,
+            parameters.PresentedOfferingContext?.ToJsonString());
     }
 
     public void TrackAdDisplayed(AdDisplayedData data) =>

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -438,9 +438,7 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
 
     public void TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams parameters)
     {
-#pragma warning disable CS0618
         var offeringId = parameters.OfferingId;
-#pragma warning restore CS0618
         CallPurchases("trackCustomPaywallImpression", parameters.PaywallId, offeringId,
             parameters.PresentedOfferingContext?.ToJsonString());
     }

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -440,7 +440,7 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
     {
         var offeringId = parameters.OfferingId;
         CallPurchases("trackCustomPaywallImpression", parameters.PaywallId, offeringId,
-            parameters.PresentedOfferingContextJson);
+            parameters.PresentedOfferingContext?.ToJsonString());
     }
 
     public void TrackAdDisplayed(AdDisplayedData data) =>

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -440,7 +440,7 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
     {
         var offeringId = parameters.OfferingId;
         CallPurchases("trackCustomPaywallImpression", parameters.PaywallId, offeringId,
-            parameters.PresentedOfferingContext?.ToJsonString());
+            parameters.PresentedOfferingContextJson);
     }
 
     public void TrackAdDisplayed(AdDisplayedData data) =>

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -540,10 +540,14 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
         _RCPurchasePackageWithWinBackOffer(package.Identifier, package.PresentedOfferingContext.ToJsonString(), winBackOffer.Identifier);
     }
     [DllImport("__Internal")]
-    private static extern void _RCTrackCustomPaywallImpression(string paywallId, string offeringId);
+    private static extern void _RCTrackCustomPaywallImpression(string paywallId, string offeringId, string presentedOfferingContextJSON);
     public void TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams parameters)
     {
-        _RCTrackCustomPaywallImpression(parameters.PaywallId, parameters.OfferingId);
+#pragma warning disable CS0618
+        var offeringId = parameters.OfferingId;
+#pragma warning restore CS0618
+        _RCTrackCustomPaywallImpression(parameters.PaywallId, offeringId,
+            parameters.PresentedOfferingContext?.ToJsonString());
     }
 
     [DllImport("__Internal")]

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -545,7 +545,7 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     {
         var offeringId = parameters.OfferingId;
         _RCTrackCustomPaywallImpression(parameters.PaywallId, offeringId,
-            parameters.PresentedOfferingContext?.ToJsonString());
+            parameters.PresentedOfferingContextJson);
     }
 
     [DllImport("__Internal")]

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -543,9 +543,7 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     private static extern void _RCTrackCustomPaywallImpression(string paywallId, string offeringId, string presentedOfferingContextJSON);
     public void TrackCustomPaywallImpression(Purchases.CustomPaywallImpressionParams parameters)
     {
-#pragma warning disable CS0618
         var offeringId = parameters.OfferingId;
-#pragma warning restore CS0618
         _RCTrackCustomPaywallImpression(parameters.PaywallId, offeringId,
             parameters.PresentedOfferingContext?.ToJsonString());
     }

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -545,7 +545,7 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     {
         var offeringId = parameters.OfferingId;
         _RCTrackCustomPaywallImpression(parameters.PaywallId, offeringId,
-            parameters.PresentedOfferingContextJson);
+            parameters.PresentedOfferingContext?.ToJsonString());
     }
 
     [DllImport("__Internal")]


### PR DESCRIPTION
Based on PHC PR https://github.com/RevenueCat/purchases-hybrid-common/pull/1665.

## API

We will now send the `presentedOfferingContext` from the passed `Offering` along with the event. This PR adds the new API variant that takes an `Offering` instead of a plain string `offeringId`. The latter is now deprecated in favor of this new API variant. We will derive the `presentedOfferingContext` from this `Offering` and send it along with the request.

```
Purchases.TrackCustomPaywallImpression(
    Purchases.CustomPaywallImpressionParams.FromOffering(offering, paywallId: "")
);
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics/API extension with backward-compatible obsolete overloads; no purchase or auth changes.
> 
> **Overview**
> Custom paywall impression tracking now accepts an **`Offering`** on `CustomPaywallImpressionParams` so analytics can include **placement and targeting** via `presentedOfferingContext` (taken from the first package’s context). The **`offeringId`-only constructor is marked obsolete**; callers should pass an `Offering` instead.
> 
> **Android and iOS** bridges forward a third argument—serialized `presentedOfferingContext`—into hybrid common, with **null-stripping** on parsed JSON before the event is sent. Integration API tests cover both legacy and offering-based call paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cf862bcc91b17ebc0de185897fb37eb38738f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->