### PR TITLE
Sub tester: Allow HTTPS request debugging and fix offerings logging crash

### DIFF
--- a/Subtester/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Subtester/Assets/Plugins/Android/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.unity3d.player"
     xmlns:tools="http://schemas.android.com/tools">
-    <application>
+    <application android:networkSecurityConfig="@xml/network_security_config">
         <activity android:name="com.unity3d.player.UnityPlayerActivity"
                   android:theme="@style/UnityThemeSelector">
             <intent-filter>

--- a/Subtester/Assets/Plugins/Android/network-security-config.androidlib.meta
+++ b/Subtester/Assets/Plugins/Android/network-security-config.androidlib.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3c668d234bf84b28aa514df15eb4fe2

--- a/Subtester/Assets/Plugins/Android/network-security-config.androidlib/build.gradle
+++ b/Subtester/Assets/Plugins/Android/network-security-config.androidlib/build.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'com.android.library'
+
+android {
+    namespace 'com.revenuecat.paywall_tester.networksecurity'
+    compileSdk getProperty("unity.compileSdkVersion") as int
+
+    sourceSets {
+        main {
+            manifest.srcFile 'src/main/AndroidManifest.xml'
+            res.srcDirs = ['src/main/res']
+        }
+    }
+
+    def unityLib = project(':unityLibrary').extensions.getByName('android')
+
+    defaultConfig {
+        minSdkVersion unityLib.defaultConfig.minSdkVersion.mApiLevel
+        targetSdkVersion unityLib.defaultConfig.targetSdkVersion.mApiLevel
+    }
+}

--- a/Subtester/Assets/Plugins/Android/network-security-config.androidlib/src/main/AndroidManifest.xml
+++ b/Subtester/Assets/Plugins/Android/network-security-config.androidlib/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/Subtester/Assets/Plugins/Android/network-security-config.androidlib/src/main/res/xml/network_security_config.xml
+++ b/Subtester/Assets/Plugins/Android/network-security-config.androidlib/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/Subtester/Assets/Tester/Scripts/Screens/OfferingsScreen.cs
+++ b/Subtester/Assets/Tester/Scripts/Screens/OfferingsScreen.cs
@@ -16,7 +16,7 @@ namespace RevenueCat.Tester.Screens
                 {
                     if (error != null) { LogError(error); return; }
                     LogSuccess("Offerings received");
-                    Log(offerings.ToString());
+                    LogOfferingsSummary(offerings);
                 });
             });
 
@@ -27,7 +27,7 @@ namespace RevenueCat.Tester.Screens
                 {
                     if (error != null) { LogError(error); return; }
                     LogSuccess("Synced attributes and offerings");
-                    Log(offerings.ToString());
+                    LogOfferingsSummary(offerings);
                 });
             });
 
@@ -148,6 +148,30 @@ namespace RevenueCat.Tester.Screens
                     }
                 });
             });
+        }
+
+        private void LogOfferingsSummary(Purchases.Offerings offerings)
+        {
+            if (offerings == null)
+            {
+                Log("Offerings: <null>");
+                return;
+            }
+
+            var currentOfferingId = offerings.Current?.Identifier ?? "none";
+            var offeringCount = offerings.All?.Count ?? 0;
+            Log($"Current offering: {currentOfferingId}");
+            Log($"Offerings count: {offeringCount}");
+
+            if (offerings.All == null) return;
+
+            foreach (var offering in offerings.All.Values)
+            {
+                var packageCount = offering.AvailablePackages?.Count ?? 0;
+                var context = packageCount > 0 ? offering.AvailablePackages[0].PresentedOfferingContext : null;
+                var contextOfferingId = context?.OfferingIdentifier ?? "none";
+                Log($"  - {offering.Identifier}: {packageCount} package(s), context offering: {contextOfferingId}");
+            }
         }
     }
 }


### PR DESCRIPTION
Two small subtester changes:

- Adds a `network_security_config` that allows for intercepting HTTPS request in order to debug them using a proxy
- Updated offerings response logging from logging the full response to just logging a summary per offering, this avoids crashes when a large offerings response is received

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Trusting user CAs weakens TLS pinning assumptions and is appropriate for a tester build but would be risky if shipped to production; offerings logging change is low-risk tester UI only.
> 
> **Overview**
> **Android (Subtester)** wires the app to a **network security config** that trusts both system and **user-installed** certificate authorities, so HTTPS traffic can be inspected with a debugging proxy. This is delivered as a small Unity Android library plus `android:networkSecurityConfig` on the main application manifest.
> 
> **Offerings screen** stops logging the full `offerings.ToString()` after fetch/sync and instead uses a new **`LogOfferingsSummary`** helper that prints current offering id, count, and per-offering package/context lines—avoiding crashes when offerings payloads are very large.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d3d4f6f69dfcdd1df4c07a7ed7e03b1646fbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->