### PR TITLE
chore: Add 3-day Dependabot cooldown, excluding fastlane plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
+      exclude:
+        - "fastlane-plugin-revenuecat_internal"


### PR DESCRIPTION
Adds a 3-day cooldown to Dependabot so we don't pick up dependency versions that were released less than 3 days ago. Our own `fastlane-plugin-revenuecat_internal` is excluded from the cooldown so it continues to update immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/dependabot.yml` changes; it affects when dependency update PRs open, not runtime app behavior.
> 
> **Overview**
> **Dependabot** for the root **Bundler** ecosystem now uses a **3-day cooldown** (`default-days: 3`) so daily PRs don’t target packages released in the last few days.
> 
> **`fastlane-plugin-revenuecat_internal`** is on the cooldown **exclude** list so that internal plugin can still be bumped as soon as Dependabot sees a new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b5fbab933391f4a030a6162fc3d6526fb37c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->