### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ aliases:
         only: main
 
 orbs:
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.21.2
   unity: game-ci/unity@1.7.1
 
 executors:


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single orb version bump with no application or pipeline structure changes; risk is limited to CI/release automation behavior.
> 
> **Overview**
> Updates the CircleCI **`revenuecat/sdks-common-config`** orb from **3.16.0** to **3.21.2** in `.circleci/config.yml`. No workflow or job definitions in this repo change—only the orb version pin.
> 
> This pulls in a fix from the shared orb so **`revenuecat/merge-release-pr`** (used in the deploy workflow after `github-release`) no longer fails after a successful merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7307d9ed705273a58a5be268dd5f89c738221c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->