### PR TITLE
feat: Expose autoResumeDate/displayName/managementURL/productPlanIdentifier on SubscriptionInfo

### DIFF
--- a/IntegrationTests/Assets/APITests/SubscriptionInfoAPITests.cs
+++ b/IntegrationTests/Assets/APITests/SubscriptionInfoAPITests.cs
@@ -23,6 +23,10 @@ namespace DefaultNamespace
             string? storeTransactionId = subscriptionInfo.StoreTransactionId;
             bool isActive = subscriptionInfo.IsActive;
             bool willRenew = subscriptionInfo.WillRenew;
+            DateTime? autoResumeDate = subscriptionInfo.AutoResumeDate;
+            string? displayName = subscriptionInfo.DisplayName;
+            string? managementURL = subscriptionInfo.ManagementURL;
+            string? productPlanIdentifier = subscriptionInfo.ProductPlanIdentifier;
         }
     }
 }

--- a/RevenueCat/Scripts/SubscriptionInfo.cs
+++ b/RevenueCat/Scripts/SubscriptionInfo.cs
@@ -27,6 +27,10 @@ public partial class Purchases
         public readonly string? StoreTransactionId;
         public readonly bool IsActive;
         public readonly bool WillRenew;
+        public readonly DateTime? AutoResumeDate;
+        public readonly string? DisplayName;
+        public readonly string? ManagementURL;
+        public readonly string? ProductPlanIdentifier;
 
         public SubscriptionInfo(JSONNode response)
         {
@@ -49,6 +53,10 @@ public partial class Purchases
             StoreTransactionId = response["storeTransactionId"];
             IsActive = response["isActive"].AsBool;
             WillRenew = response["willRenew"].AsBool;
+            AutoResumeDate = FromResponseISO8601String(response, "autoResumeDate");
+            DisplayName = response["displayName"];
+            ManagementURL = response["managementURL"];
+            ProductPlanIdentifier = response["productPlanIdentifier"];
         }
 
         public override string ToString()
@@ -68,7 +76,11 @@ public partial class Purchases
                 $"{nameof(RefundedAt)}: {RefundedAt}\n" +
                 $"{nameof(StoreTransactionId)}: {StoreTransactionId}\n" +
                 $"{nameof(IsActive)}: {IsActive}\n" +
-                $"{nameof(WillRenew)}: {WillRenew}";
+                $"{nameof(WillRenew)}: {WillRenew}\n" +
+                $"{nameof(AutoResumeDate)}: {AutoResumeDate}\n" +
+                $"{nameof(DisplayName)}: {DisplayName}\n" +
+                $"{nameof(ManagementURL)}: {ManagementURL}\n" +
+                $"{nameof(ProductPlanIdentifier)}: {ProductPlanIdentifier}";
         }
 
         private DateTime? FromResponseISO8601String(JSONNode response, string key)


### PR DESCRIPTION
Adds new fields (https://github.com/RevenueCat/purchases-hybrid-common/pull/1698) to SubscriptionInfo for parity to other SDKs. These fields come through PHC's 18.8.0 release.

Part of SDK-4369.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive deserialization and public fields on an existing DTO; no auth, billing, or behavioral changes to purchase flows.
> 
> **Overview**
> Extends **`SubscriptionInfo`** with four read-only properties aligned with purchases-hybrid-common 18.8.0 and other RevenueCat SDKs: **`AutoResumeDate`**, **`DisplayName`**, **`ManagementURL`**, and **`ProductPlanIdentifier`**.
> 
> The JSON constructor maps `autoResumeDate` through the existing ISO-8601 helper; the string fields are read directly from the native response. **`ToString`** includes the new values, and the integration API test touches each property so the public surface compiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a59f74ccf900df1b2fe88e15a077e1a154806bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->