### PR TITLE
feat(ads): expose reward verification primitives

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -268,6 +268,20 @@ public class PurchasesAPITests : MonoBehaviour
         purchases.AdTracker.TrackAdFailedToLoad(new AdFailedToLoadData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "ad_unit"));
         purchases.AdTracker.TrackAdFailedToLoad(new AdFailedToLoadData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "ad_unit", placement: "home", mediatorErrorCode: 2));
 
+        // Reward verification API tests
+        purchases.GenerateRewardVerificationToken("imp_001", (token, error) =>
+        {
+            string customData = token.CustomData;
+            string clientTransactionId = token.ClientTransactionId;
+            string appUserID = token.AppUserID;
+        });
+        purchases.PollRewardVerification("client_transaction_id", (result, error) =>
+        {
+            bool failed = result.Failed;
+            Purchases.VerifiedReward reward = result.Reward;
+            List<Purchases.VerifiedReward> moreRewards = result.MoreRewards;
+        });
+
         // Win-back offer API tests
         // Purchasing win-back offers with a product
         purchases.GetProducts(new[] { "product_id" }, (products, error) =>

--- a/IntegrationTests/Assets/APITests/RewardVerificationResultAPITests.cs
+++ b/IntegrationTests/Assets/APITests/RewardVerificationResultAPITests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class RewardVerificationResultAPITests : MonoBehaviour
+    {
+        private void Start()
+        {
+            Purchases.RewardVerificationResult result = new Purchases.RewardVerificationResult(null);
+            bool failed = result.Failed;
+            Purchases.VerifiedReward reward = result.Reward;
+            List<Purchases.VerifiedReward> moreRewards = result.MoreRewards;
+        }
+    }
+}

--- a/IntegrationTests/Assets/APITests/RewardVerificationResultAPITests.cs.meta
+++ b/IntegrationTests/Assets/APITests/RewardVerificationResultAPITests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8b5dc8e92d34c80a41f0627d98ff770
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IntegrationTests/Assets/APITests/RewardVerificationTokenAPITests.cs
+++ b/IntegrationTests/Assets/APITests/RewardVerificationTokenAPITests.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class RewardVerificationTokenAPITests : MonoBehaviour
+    {
+        private void Start()
+        {
+            Purchases.RewardVerificationToken token = new Purchases.RewardVerificationToken(null);
+            string customData = token.CustomData;
+            string clientTransactionId = token.ClientTransactionId;
+            string appUserID = token.AppUserID;
+        }
+    }
+}

--- a/IntegrationTests/Assets/APITests/RewardVerificationTokenAPITests.cs.meta
+++ b/IntegrationTests/Assets/APITests/RewardVerificationTokenAPITests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cdc0e79f159483e85739e07e91bb974
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IntegrationTests/Assets/APITests/VerifiedRewardAPITests.cs
+++ b/IntegrationTests/Assets/APITests/VerifiedRewardAPITests.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class VerifiedRewardAPITests : MonoBehaviour
+    {
+        private void Start()
+        {
+            Purchases.VerifiedReward reward = new Purchases.VerifiedReward(null);
+            Purchases.VerifiedReward.RewardType type = reward.Type;
+            string code = reward.Code;
+            int amount = reward.Amount;
+            string identifier = reward.Identifier;
+            string expiresAt = reward.ExpiresAt;
+            long expiresAtMillis = reward.ExpiresAtMillis;
+
+            switch (type)
+            {
+                case Purchases.VerifiedReward.RewardType.VirtualCurrency:
+                case Purchases.VerifiedReward.RewardType.Entitlement:
+                case Purchases.VerifiedReward.RewardType.NoReward:
+                case Purchases.VerifiedReward.RewardType.Unsupported:
+                    break;
+            }
+        }
+    }
+}

--- a/IntegrationTests/Assets/APITests/VerifiedRewardAPITests.cs
+++ b/IntegrationTests/Assets/APITests/VerifiedRewardAPITests.cs
@@ -6,20 +6,22 @@ namespace DefaultNamespace
     {
         private void Start()
         {
-            Purchases.VerifiedReward reward = new Purchases.VerifiedReward(null);
-            Purchases.VerifiedReward.RewardType type = reward.Type;
-            string code = reward.Code;
-            int amount = reward.Amount;
-            string identifier = reward.Identifier;
-            string expiresAt = reward.ExpiresAt;
-            long expiresAtMillis = reward.ExpiresAtMillis;
+            Purchases.VerifiedReward reward = Purchases.VerifiedReward.FromJson(null);
 
-            switch (type)
+            switch (reward)
             {
-                case Purchases.VerifiedReward.RewardType.VirtualCurrency:
-                case Purchases.VerifiedReward.RewardType.Entitlement:
-                case Purchases.VerifiedReward.RewardType.NoReward:
-                case Purchases.VerifiedReward.RewardType.Unsupported:
+                case Purchases.VerifiedReward.VirtualCurrency virtualCurrency:
+                    string code = virtualCurrency.Code;
+                    int amount = virtualCurrency.Amount;
+                    break;
+                case Purchases.VerifiedReward.Entitlement entitlement:
+                    string identifier = entitlement.Identifier;
+                    string expiresAt = entitlement.ExpiresAt;
+                    long expiresAtMillis = entitlement.ExpiresAtMillis;
+                    break;
+                case Purchases.VerifiedReward.NoReward noReward:
+                    break;
+                case Purchases.VerifiedReward.Unsupported unsupported:
                     break;
             }
         }

--- a/IntegrationTests/Assets/APITests/VerifiedRewardAPITests.cs.meta
+++ b/IntegrationTests/Assets/APITests/VerifiedRewardAPITests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92369c88134145c49fda3cd5788b8c6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesWrapperSpy.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesWrapperSpy.cs
@@ -213,5 +213,11 @@ namespace RevenueCat.Tests
         public void TrackAdRevenue(AdRevenueData data) => Record(nameof(TrackAdRevenue), data);
         public void TrackAdLoaded(AdLoadedData data) => Record(nameof(TrackAdLoaded), data);
         public void TrackAdFailedToLoad(AdFailedToLoadData data) => Record(nameof(TrackAdFailedToLoad), data);
+
+        public void GenerateRewardVerificationToken(string impressionId) =>
+            Record(nameof(GenerateRewardVerificationToken), impressionId);
+
+        public void PollRewardVerification(string clientTransactionId) =>
+            Record(nameof(PollRewardVerification), clientTransactionId);
     }
 }

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -64,6 +64,8 @@ public class PurchasesWrapper {
     private static final String PURCHASE_PRODUCT_WITH_WIN_BACK_OFFER = "_purchaseProductWithWinBackOffer";
     private static final String PURCHASE_PACKAGE_WITH_WIN_BACK_OFFER = "_purchasePackageWithWinBackOffer";
     private static final String HANDLE_LOG = "_handleLog";
+    private static final String GENERATE_REWARD_VERIFICATION_TOKEN = "_generateRewardVerificationToken";
+    private static final String POLL_REWARD_VERIFICATION = "_pollRewardVerification";
 
     private static final String PLATFORM_NAME = "unity";
     private static final String PLUGIN_VERSION = "9.7.0";
@@ -843,6 +845,25 @@ public class PurchasesWrapper {
         } catch (JSONException e) {
             logJSONException(e);
         }
+    }
+
+    public static void generateRewardVerificationToken(String impressionId) {
+        Map<String, ?> token = CommonKt.generateRewardVerificationToken(impressionId);
+        sendJSONObject(MappersHelpersKt.convertToJson(token), GENERATE_REWARD_VERIFICATION_TOKEN);
+    }
+
+    public static void pollRewardVerification(String clientTransactionId) {
+        CommonKt.pollRewardVerification(clientTransactionId, new OnResult() {
+            @Override
+            public void onReceived(Map<String, ?> map) {
+                sendJSONObject(MappersHelpersKt.convertToJson(map), POLL_REWARD_VERIFICATION);
+            }
+
+            @Override
+            public void onError(ErrorContainer errorContainer) {
+                sendError(errorContainer, POLL_REWARD_VERIFICATION);
+            }
+        });
     }
 
     private static void logJSONException(JSONException e) {

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -693,6 +693,13 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 - (void)pollRewardVerification:(NSString *)clientTransactionId {
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:clientTransactionId
                                                              completion:^(NSDictionary *_Nullable result, RCErrorContainer *_Nullable error) {
+        if (error == nil && result == nil) {
+            NSError *nsError = [[NSError alloc] initWithDomain:RCPurchasesErrorCodeDomain
+                                                          code:RCUnknownError
+                                                      userInfo:@{NSLocalizedDescriptionKey: @"Both error and response are null"}];
+            error = [[RCErrorContainer alloc] initWithError:nsError extraPayload:@{}];
+        }
+
         NSMutableDictionary *response = [NSMutableDictionary new];
         if (error) {
             response[@"error"] = error.info;

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -40,6 +40,8 @@ static NSString *const GET_ELIGIBLE_WIN_BACK_OFFERS_FOR_PRODUCT = @"_getEligible
 static NSString *const GET_ELIGIBLE_WIN_BACK_OFFERS_FOR_PACKAGE = @"_getEligibleWinBackOffersForPackage";
 static NSString *const PURCHASE_PRODUCT_WITH_WIN_BACK_OFFER = @"_purchaseProductWithWinBackOffer";
 static NSString *const PURCHASE_PACKAGE_WITH_WIN_BACK_OFFER = @"_purchasePackageWithWinBackOffer";
+static NSString *const GENERATE_REWARD_VERIFICATION_TOKEN = @"_generateRewardVerificationToken";
+static NSString *const POLL_REWARD_VERIFICATION = @"_pollRewardVerification";
 #pragma mark Utility Methods
 
 NSString *convertCString(const char *string) {
@@ -683,6 +685,24 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     }
 }
 
+- (void)generateRewardVerificationToken:(NSString *)impressionId {
+    NSDictionary *token = [RCCommonFunctionality generateRewardVerificationTokenWithImpressionId:impressionId];
+    [self sendJSONObject:token toMethod:GENERATE_REWARD_VERIFICATION_TOKEN];
+}
+
+- (void)pollRewardVerification:(NSString *)clientTransactionId {
+    [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:clientTransactionId
+                                                             completion:^(NSDictionary *_Nullable result, RCErrorContainer *_Nullable error) {
+        NSMutableDictionary *response = [NSMutableDictionary new];
+        if (error) {
+            response[@"error"] = error.info;
+        } else {
+            [response addEntriesFromDictionary:result];
+        }
+        [self sendJSONObject:response toMethod:POLL_REWARD_VERIFICATION];
+    }];
+}
+
 - (void)parseAsWebPurchaseRedemption:(NSString *)urlString {
     BOOL isWebPurchaseRedemptionURL = [RCCommonFunctionality isWebPurchaseRedemptionURL:urlString];
     if (isWebPurchaseRedemptionURL) {
@@ -1205,6 +1225,14 @@ void _RCTrackAdLoaded(const char *dataJson) {
 
 void _RCTrackAdFailedToLoad(const char *dataJson) {
     [_RCUnityHelperShared() trackAdFailedToLoad:convertCString(dataJson)];
+}
+
+void _RCGenerateRewardVerificationToken(const char *impressionId) {
+    [_RCUnityHelperShared() generateRewardVerificationToken:convertCString(impressionId)];
+}
+
+void _RCPollRewardVerification(const char *clientTransactionId) {
+    [_RCUnityHelperShared() pollRewardVerification:convertCString(clientTransactionId)];
 }
 
 @implementation NSObject (NSNullMapping)

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -697,6 +697,59 @@ public partial class Purchases : MonoBehaviour
     }
 
     /// <summary>
+    /// Callback for <see cref="Purchases.GenerateRewardVerificationToken"/>.
+    /// </summary>
+    /// <param name="token"> The generated token if the request was successful, null otherwise.</param>
+    /// <param name="error"> The error if the request was unsuccessful, null otherwise.</param>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public delegate void GenerateRewardVerificationTokenFunc(RewardVerificationToken token, Error error);
+
+    private GenerateRewardVerificationTokenFunc GenerateRewardVerificationTokenCallback { get; set; }
+
+    /// <summary>
+    /// Callback for <see cref="Purchases.PollRewardVerification"/>.
+    /// </summary>
+    /// <param name="result"> The verification result if the request was successful, null otherwise.</param>
+    /// <param name="error"> The error if the request was unsuccessful, null otherwise.</param>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public delegate void PollRewardVerificationFunc(RewardVerificationResult result, Error error);
+
+    private PollRewardVerificationFunc PollRewardVerificationCallback { get; set; }
+
+    /// <summary>
+    /// Generates a reward verification token for a rewarded ad impression.
+    ///
+    /// Pass the returned <see cref="RewardVerificationToken.ClientTransactionId"/> to the ad
+    /// network as the server-side verification custom data. After the ad completes, pass the same
+    /// id to <see cref="PollRewardVerification"/> to await the reward.
+    /// </summary>
+    /// <param name="impressionId"> The impression identifier of the rewarded ad.</param>
+    /// <param name="callback"> Called with the generated token, or an error if generation failed.</param>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public void GenerateRewardVerificationToken(string impressionId, GenerateRewardVerificationTokenFunc callback)
+    {
+        GenerateRewardVerificationTokenCallback = callback;
+        _wrapper.GenerateRewardVerificationToken(impressionId);
+    }
+
+    /// <summary>
+    /// Polls RevenueCat for the reward verification result of a rewarded ad.
+    ///
+    /// The callback fires once the native poller completes or times out (up to ~10-30s). A
+    /// timed-out or rejected verification reports a result with <see cref="RewardVerificationResult.Failed"/>
+    /// set to true rather than an error.
+    /// </summary>
+    /// <param name="clientTransactionId"> The <see cref="RewardVerificationToken.ClientTransactionId"/>
+    /// from <see cref="GenerateRewardVerificationToken"/>.</param>
+    /// <param name="callback"> Called with the verification result, or an error if polling failed.</param>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public void PollRewardVerification(string clientTransactionId, PollRewardVerificationFunc callback)
+    {
+        PollRewardVerificationCallback = callback;
+        _wrapper.PollRewardVerification(clientTransactionId);
+    }
+
+    /// <summary>
     /// This method will post all purchases associated with the current App Store account to RevenueCat and
     /// become associated with the current <c>appUserID</c>.
     /// </summary>
@@ -1700,6 +1753,42 @@ public partial class Purchases : MonoBehaviour
         {
             var offeringsResponse = response["offerings"];
             callback(new Offerings(offeringsResponse), null);
+        }
+    }
+
+    // ReSharper disable once UnusedMember.Local
+    private void _generateRewardVerificationToken(string tokenJson)
+    {
+        Debug.Log("_generateRewardVerificationToken " + tokenJson);
+        if (GenerateRewardVerificationTokenCallback == null) return;
+        var response = JSON.Parse(tokenJson);
+        var callback = GenerateRewardVerificationTokenCallback;
+        GenerateRewardVerificationTokenCallback = null;
+        if (ResponseHasError(response))
+        {
+            callback(null, new Error(response["error"]));
+        }
+        else
+        {
+            callback(new RewardVerificationToken(response), null);
+        }
+    }
+
+    // ReSharper disable once UnusedMember.Local
+    private void _pollRewardVerification(string resultJson)
+    {
+        Debug.Log("_pollRewardVerification " + resultJson);
+        if (PollRewardVerificationCallback == null) return;
+        var response = JSON.Parse(resultJson);
+        var callback = PollRewardVerificationCallback;
+        PollRewardVerificationCallback = null;
+        if (ResponseHasError(response))
+        {
+            callback(null, new Error(response["error"]));
+        }
+        else
+        {
+            callback(new RewardVerificationResult(response), null);
         }
     }
 

--- a/RevenueCat/Scripts/PurchasesWrapper.cs
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs
@@ -99,4 +99,6 @@ public interface IPurchasesWrapper
     void TrackAdRevenue(AdRevenueData data);
     void TrackAdLoaded(AdLoadedData data);
     void TrackAdFailedToLoad(AdFailedToLoadData data);
+    void GenerateRewardVerificationToken(string impressionId);
+    void PollRewardVerification(string clientTransactionId);
 }

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -467,6 +467,12 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
     public void TrackAdFailedToLoad(AdFailedToLoadData data) =>
         CallPurchases("trackAdFailedToLoad", data.ToJsonString());
 
+    public void GenerateRewardVerificationToken(string impressionId) =>
+        CallPurchases("generateRewardVerificationToken", impressionId);
+
+    public void PollRewardVerification(string clientTransactionId) =>
+        CallPurchases("pollRewardVerification", clientTransactionId);
+
     private const string PurchasesWrapper = "com.revenuecat.purchasesunity.PurchasesWrapper";
 
     private static void CallPurchases(string methodName, params object[] args)

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs
@@ -304,5 +304,7 @@ public partial class Purchases
         public void TrackAdRevenue(AdRevenueData data) { }
         public void TrackAdLoaded(AdLoadedData data) { }
         public void TrackAdFailedToLoad(AdFailedToLoadData data) { }
+        public void GenerateRewardVerificationToken(string impressionId) { }
+        public void PollRewardVerification(string clientTransactionId) { }
     }
 }

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -584,5 +584,15 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     private static extern void _RCTrackAdFailedToLoad(string dataJson);
     public void TrackAdFailedToLoad(AdFailedToLoadData data) =>
         _RCTrackAdFailedToLoad(data.ToJsonString());
+
+    [DllImport("__Internal")]
+    private static extern void _RCGenerateRewardVerificationToken(string impressionId);
+    public void GenerateRewardVerificationToken(string impressionId) =>
+        _RCGenerateRewardVerificationToken(impressionId);
+
+    [DllImport("__Internal")]
+    private static extern void _RCPollRewardVerification(string clientTransactionId);
+    public void PollRewardVerification(string clientTransactionId) =>
+        _RCPollRewardVerification(clientTransactionId);
 }
 #endif

--- a/RevenueCat/Scripts/RewardVerificationResult.cs
+++ b/RevenueCat/Scripts/RewardVerificationResult.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using RevenueCat.SimpleJSON;
+using static RevenueCat.Utilities;
+
+public partial class Purchases
+{
+    /// <summary>
+    /// Result of polling for reward verification. A single ad can grant multiple rewards.
+    /// </summary>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public class RewardVerificationResult
+    {
+        /// <summary>
+        /// The primary reward when verification succeeded; null on failure.
+        /// </summary>
+        public readonly VerifiedReward Reward;
+
+        /// <summary>
+        /// Additional rewards granted alongside the primary; never repeats it; empty on failure.
+        /// </summary>
+        public readonly List<VerifiedReward> MoreRewards;
+
+        /// <summary>
+        /// True when verification did not complete (rejected / timeout / network).
+        /// </summary>
+        public readonly bool Failed;
+
+        public RewardVerificationResult(JSONNode response)
+        {
+            Failed = response["failed"].AsBool;
+            MoreRewards = new List<VerifiedReward>();
+
+            if (Failed) return;
+
+            if (response["reward"] != null && !response["reward"].IsNull)
+            {
+                Reward = new VerifiedReward(response["reward"]);
+            }
+
+            foreach (JSONNode rewardNode in response["moreRewards"].AsArray)
+            {
+                MoreRewards.Add(new VerifiedReward(rewardNode));
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Failed)}: {Failed}, " +
+                   $"{nameof(Reward)}: {(Reward == null ? "null" : Reward.ToString())}, " +
+                   $"{nameof(MoreRewards)}:\n{ListToString(MoreRewards)}";
+        }
+    }
+}

--- a/RevenueCat/Scripts/RewardVerificationResult.cs
+++ b/RevenueCat/Scripts/RewardVerificationResult.cs
@@ -37,7 +37,7 @@ public partial class Purchases
                 Reward = VerifiedReward.FromJson(response["reward"]);
             }
 
-            foreach (JSONNode rewardNode in response["moreRewards"].AsArray)
+            foreach (JSONNode rewardNode in response["moreRewards"])
             {
                 MoreRewards.Add(VerifiedReward.FromJson(rewardNode));
             }

--- a/RevenueCat/Scripts/RewardVerificationResult.cs
+++ b/RevenueCat/Scripts/RewardVerificationResult.cs
@@ -34,12 +34,12 @@ public partial class Purchases
 
             if (response["reward"] != null && !response["reward"].IsNull)
             {
-                Reward = new VerifiedReward(response["reward"]);
+                Reward = VerifiedReward.FromJson(response["reward"]);
             }
 
             foreach (JSONNode rewardNode in response["moreRewards"].AsArray)
             {
-                MoreRewards.Add(new VerifiedReward(rewardNode));
+                MoreRewards.Add(VerifiedReward.FromJson(rewardNode));
             }
         }
 

--- a/RevenueCat/Scripts/RewardVerificationResult.cs.meta
+++ b/RevenueCat/Scripts/RewardVerificationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1978bcc8318a4b388e8e6ed89eb376c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/RewardVerificationToken.cs
+++ b/RevenueCat/Scripts/RewardVerificationToken.cs
@@ -1,0 +1,42 @@
+using RevenueCat.SimpleJSON;
+
+public partial class Purchases
+{
+    /// <summary>
+    /// Token generated for a rewarded ad impression. Pass <see cref="ClientTransactionId"/>
+    /// to the ad network as server-side verification custom data, then to
+    /// <see cref="Purchases.PollRewardVerification"/> to await the reward.
+    /// </summary>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public class RewardVerificationToken
+    {
+        /// <summary>
+        /// Custom data to forward to the ad network for server-side verification.
+        /// </summary>
+        public readonly string CustomData;
+
+        /// <summary>
+        /// The transaction identifier to poll with <see cref="Purchases.PollRewardVerification"/>.
+        /// </summary>
+        public readonly string ClientTransactionId;
+
+        /// <summary>
+        /// The app user ID the token was generated for.
+        /// </summary>
+        public readonly string AppUserID;
+
+        public RewardVerificationToken(JSONNode response)
+        {
+            CustomData = response["customData"];
+            ClientTransactionId = response["clientTransactionId"];
+            AppUserID = response["appUserID"];
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(CustomData)}: {CustomData}, " +
+                   $"{nameof(ClientTransactionId)}: {ClientTransactionId}, " +
+                   $"{nameof(AppUserID)}: {AppUserID}";
+        }
+    }
+}

--- a/RevenueCat/Scripts/RewardVerificationToken.cs.meta
+++ b/RevenueCat/Scripts/RewardVerificationToken.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43bc8cc8113d4ca1959ff019daffe00d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RevenueCat/Scripts/VerifiedReward.cs
+++ b/RevenueCat/Scripts/VerifiedReward.cs
@@ -1,0 +1,99 @@
+using RevenueCat.SimpleJSON;
+
+public partial class Purchases
+{
+    /// <summary>
+    /// A reward granted after a verified rewarded ad. Inspect <see cref="Type"/> to
+    /// determine which fields are populated.
+    /// </summary>
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public class VerifiedReward
+    {
+        /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+        public enum RewardType
+        {
+            /// A virtual currency reward. <see cref="Code"/> and <see cref="Amount"/> are populated.
+            VirtualCurrency,
+            /// An entitlement reward. <see cref="Identifier"/>, <see cref="ExpiresAt"/> and
+            /// <see cref="ExpiresAtMillis"/> are populated.
+            Entitlement,
+            /// Verification completed but nothing was granted.
+            NoReward,
+            /// Verification completed but the reward type isn't modeled by this SDK version.
+            Unsupported
+        }
+
+        /// <summary>
+        /// The kind of reward. Determines which of the fields below are populated.
+        /// </summary>
+        public readonly RewardType Type;
+
+        /// <summary>
+        /// The virtual currency code. Populated when <see cref="Type"/> is
+        /// <see cref="RewardType.VirtualCurrency"/>.
+        /// </summary>
+        public readonly string Code;
+
+        /// <summary>
+        /// The virtual currency amount granted. Populated when <see cref="Type"/> is
+        /// <see cref="RewardType.VirtualCurrency"/>.
+        /// </summary>
+        public readonly int Amount;
+
+        /// <summary>
+        /// The entitlement identifier. Populated when <see cref="Type"/> is
+        /// <see cref="RewardType.Entitlement"/>.
+        /// </summary>
+        public readonly string Identifier;
+
+        /// <summary>
+        /// ISO 8601 expiration date string. Populated when <see cref="Type"/> is
+        /// <see cref="RewardType.Entitlement"/>.
+        /// </summary>
+        public readonly string ExpiresAt;
+
+        /// <summary>
+        /// Expiration date in milliseconds since epoch. Populated when <see cref="Type"/> is
+        /// <see cref="RewardType.Entitlement"/>.
+        /// </summary>
+        public readonly long ExpiresAtMillis;
+
+        public VerifiedReward(JSONNode response)
+        {
+            switch ((string) response["type"])
+            {
+                case "virtual_currency":
+                    Type = RewardType.VirtualCurrency;
+                    Code = response["code"];
+                    Amount = response["amount"];
+                    break;
+                case "entitlement":
+                    Type = RewardType.Entitlement;
+                    Identifier = response["identifier"];
+                    ExpiresAt = response["expiresAt"];
+                    ExpiresAtMillis = response["expiresAtMillis"].AsLong;
+                    break;
+                case "no_reward":
+                    Type = RewardType.NoReward;
+                    break;
+                default:
+                    Type = RewardType.Unsupported;
+                    break;
+            }
+        }
+
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case RewardType.VirtualCurrency:
+                    return $"{nameof(Type)}: {Type}, {nameof(Code)}: {Code}, {nameof(Amount)}: {Amount}";
+                case RewardType.Entitlement:
+                    return $"{nameof(Type)}: {Type}, {nameof(Identifier)}: {Identifier}, " +
+                           $"{nameof(ExpiresAt)}: {ExpiresAt}, {nameof(ExpiresAtMillis)}: {ExpiresAtMillis}";
+                default:
+                    return $"{nameof(Type)}: {Type}";
+            }
+        }
+    }
+}

--- a/RevenueCat/Scripts/VerifiedReward.cs
+++ b/RevenueCat/Scripts/VerifiedReward.cs
@@ -3,96 +3,98 @@ using RevenueCat.SimpleJSON;
 public partial class Purchases
 {
     /// <summary>
-    /// A reward granted after a verified rewarded ad. Inspect <see cref="Type"/> to
-    /// determine which fields are populated.
+    /// A reward granted after a verified rewarded ad. Switch on the concrete subtype to read the
+    /// fields relevant to that reward.
     /// </summary>
     /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
-    public class VerifiedReward
+    public abstract class VerifiedReward
     {
-        /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
-        public enum RewardType
+        private VerifiedReward() { }
+
+        /// <summary>
+        /// A virtual currency reward.
+        /// </summary>
+        public sealed class VirtualCurrency : VerifiedReward
         {
-            /// A virtual currency reward. <see cref="Code"/> and <see cref="Amount"/> are populated.
-            VirtualCurrency,
-            /// An entitlement reward. <see cref="Identifier"/>, <see cref="ExpiresAt"/> and
-            /// <see cref="ExpiresAtMillis"/> are populated.
-            Entitlement,
-            /// Verification completed but nothing was granted.
-            NoReward,
-            /// Verification completed but the reward type isn't modeled by this SDK version.
-            Unsupported
+            /// The virtual currency code.
+            public readonly string Code;
+
+            /// The virtual currency amount granted.
+            public readonly int Amount;
+
+            public VirtualCurrency(string code, int amount)
+            {
+                Code = code;
+                Amount = amount;
+            }
+
+            public override string ToString() =>
+                $"{nameof(VirtualCurrency)}({nameof(Code)}: {Code}, {nameof(Amount)}: {Amount})";
         }
 
         /// <summary>
-        /// The kind of reward. Determines which of the fields below are populated.
+        /// An entitlement reward.
         /// </summary>
-        public readonly RewardType Type;
+        public sealed class Entitlement : VerifiedReward
+        {
+            /// The entitlement identifier.
+            public readonly string Identifier;
+
+            /// ISO 8601 expiration date string.
+            public readonly string ExpiresAt;
+
+            /// Expiration date in milliseconds since epoch.
+            public readonly long ExpiresAtMillis;
+
+            public Entitlement(string identifier, string expiresAt, long expiresAtMillis)
+            {
+                Identifier = identifier;
+                ExpiresAt = expiresAt;
+                ExpiresAtMillis = expiresAtMillis;
+            }
+
+            public override string ToString() =>
+                $"{nameof(Entitlement)}({nameof(Identifier)}: {Identifier}, " +
+                $"{nameof(ExpiresAt)}: {ExpiresAt}, {nameof(ExpiresAtMillis)}: {ExpiresAtMillis})";
+        }
 
         /// <summary>
-        /// The virtual currency code. Populated when <see cref="Type"/> is
-        /// <see cref="RewardType.VirtualCurrency"/>.
+        /// Verification completed but nothing was granted.
         /// </summary>
-        public readonly string Code;
+        public sealed class NoReward : VerifiedReward
+        {
+            private NoReward() { }
+            public static NoReward Instance { get; } = new NoReward();
+
+            public override string ToString() => nameof(NoReward);
+        }
 
         /// <summary>
-        /// The virtual currency amount granted. Populated when <see cref="Type"/> is
-        /// <see cref="RewardType.VirtualCurrency"/>.
+        /// Verification completed but the reward type isn't modeled by this SDK version.
         /// </summary>
-        public readonly int Amount;
+        public sealed class Unsupported : VerifiedReward
+        {
+            private Unsupported() { }
+            public static Unsupported Instance { get; } = new Unsupported();
 
-        /// <summary>
-        /// The entitlement identifier. Populated when <see cref="Type"/> is
-        /// <see cref="RewardType.Entitlement"/>.
-        /// </summary>
-        public readonly string Identifier;
+            public override string ToString() => nameof(Unsupported);
+        }
 
-        /// <summary>
-        /// ISO 8601 expiration date string. Populated when <see cref="Type"/> is
-        /// <see cref="RewardType.Entitlement"/>.
-        /// </summary>
-        public readonly string ExpiresAt;
-
-        /// <summary>
-        /// Expiration date in milliseconds since epoch. Populated when <see cref="Type"/> is
-        /// <see cref="RewardType.Entitlement"/>.
-        /// </summary>
-        public readonly long ExpiresAtMillis;
-
-        public VerifiedReward(JSONNode response)
+        public static VerifiedReward FromJson(JSONNode response)
         {
             switch ((string) response["type"])
             {
                 case "virtual_currency":
-                    Type = RewardType.VirtualCurrency;
-                    Code = response["code"];
-                    Amount = response["amount"];
-                    break;
+                    return new VirtualCurrency(response["code"], response["amount"]);
                 case "entitlement":
-                    Type = RewardType.Entitlement;
-                    Identifier = response["identifier"];
-                    ExpiresAt = response["expiresAt"];
-                    ExpiresAtMillis = response["expiresAtMillis"].AsLong;
-                    break;
+                    return new Entitlement(
+                        response["identifier"],
+                        response["expiresAt"],
+                        response["expiresAtMillis"].AsLong);
                 case "no_reward":
-                    Type = RewardType.NoReward;
-                    break;
+                    return NoReward.Instance;
                 default:
-                    Type = RewardType.Unsupported;
-                    break;
-            }
-        }
-
-        public override string ToString()
-        {
-            switch (Type)
-            {
-                case RewardType.VirtualCurrency:
-                    return $"{nameof(Type)}: {Type}, {nameof(Code)}: {Code}, {nameof(Amount)}: {Amount}";
-                case RewardType.Entitlement:
-                    return $"{nameof(Type)}: {Type}, {nameof(Identifier)}: {Identifier}, " +
-                           $"{nameof(ExpiresAt)}: {ExpiresAt}, {nameof(ExpiresAtMillis)}: {ExpiresAtMillis}";
-                default:
-                    return $"{nameof(Type)}: {Type}";
+                    return Unsupported.Instance;
             }
         }
     }

--- a/RevenueCat/Scripts/VerifiedReward.cs.meta
+++ b/RevenueCat/Scripts/VerifiedReward.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c30e4d8c82c84d3d92486adc1564edfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description

Exposes the rewarded ad verification primitives. We do not support Unity AdMob adapters so this is the way to use it from Unity.

- `Purchases.GenerateRewardVerificationToken(impressionId, callback)`
- `Purchases.PollRewardVerification(clientTransactionId, callback)`

We are using callback/delegate style as that is the convention in the repository. 

Tested e2e with a sample unity app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New experimental ad-reward API affects monetization flows and depends on hybrid-common behavior; failures/timeouts are modeled as `Failed` rather than errors, so callers must handle both paths correctly.
> 
> **Overview**
> Adds **experimental** rewarded-ad verification to the Unity SDK so games can verify rewards without Unity AdMob adapters.
> 
> **`Purchases.GenerateRewardVerificationToken(impressionId, callback)`** returns a `RewardVerificationToken` (`CustomData`, `ClientTransactionId`, `AppUserID`). Pass `ClientTransactionId` to the ad network for server-side verification custom data.
> 
> **`Purchases.PollRewardVerification(clientTransactionId, callback)`** waits for RevenueCat’s result and returns `RewardVerificationResult` with `Failed`, primary `Reward`, and `MoreRewards`. Timeouts/rejections surface as `Failed == true` rather than callback errors.
> 
> New **`VerifiedReward`** subtypes cover virtual currency, entitlement, no reward, and unsupported types via `FromJson`. The path is wired through `IPurchasesWrapper`, Android `PurchasesWrapper.java`, iOS `PurchasesUnityHelper.m`, and noop/iOS/Android C# wrappers, with integration API tests and spy updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d0f2506e8ce1b7c5f3a6b111567594e069b47a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->