### PR TITLE
Add preferred UI locale override, diagnosticsEnabled and automaticDeviceIdentifierCollectionEnabled configuration options

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -225,6 +225,8 @@ public class PurchasesAPITests : MonoBehaviour
             .SetShouldShowInAppMessagesAutomatically(false)
             .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
             .SetPendingTransactionsForPrepaidPlansEnabled(true)
+            .SetDiagnosticsEnabled(true)
+            .SetAutomaticDeviceIdentifierCollectionEnabled(false)
             .SetPreferredUILocaleOverride("de_DE")
             .Build();
         purchases.Configure(purchasesConfiguration);

--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -170,6 +170,8 @@ public class PurchasesAPITests : MonoBehaviour
         purchases.CheckTrialOrIntroductoryPriceEligibility(new string[] { "a", "b" },
             eligibilities => { receivedEligibilities = eligibilities; });
         purchases.InvalidateCustomerInfoCache();
+        purchases.OverridePreferredUILocale("de_DE");
+        purchases.OverridePreferredUILocale(null);
         purchases.PresentCodeRedemptionSheet();
         purchases.SetSimulatesAskToBuyInSandbox(true);
 
@@ -223,6 +225,7 @@ public class PurchasesAPITests : MonoBehaviour
             .SetShouldShowInAppMessagesAutomatically(false)
             .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
             .SetPendingTransactionsForPrepaidPlansEnabled(true)
+            .SetPreferredUILocaleOverride("de_DE")
             .Build();
         purchases.Configure(purchasesConfiguration);
         purchases.RecordPurchase("product_id", (transaction, error) => 

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -92,14 +92,18 @@ public class PurchasesWrapper {
                              boolean shouldShowInAppMessagesAutomatically,
                              String dangerousSettingsJSON,
                              String entitlementVerificationMode,
-                             boolean pendingTransactionsForPrepaidPlansEnabled) {
+                             boolean pendingTransactionsForPrepaidPlansEnabled,
+                             String preferredUILocaleOverride) {
         PurchasesWrapper.gameObject = gameObject;
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         Store store = useAmazon ? Store.AMAZON : Store.PLAY_STORE;
         DangerousSettings dangerousSettings = getDangerousSettingsFromJSON(dangerousSettingsJSON);
         CommonKt.configure(UnityPlayer.currentActivity, apiKey, appUserId, purchasesAreCompletedBy, platformInfo, store,
                 dangerousSettings, shouldShowInAppMessagesAutomatically, entitlementVerificationMode,
-                pendingTransactionsForPrepaidPlansEnabled);
+                pendingTransactionsForPrepaidPlansEnabled,
+                null, // diagnosticsEnabled
+                null, // automaticDeviceIdentifierCollectionEnabled
+                preferredUILocaleOverride);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(listener);
     }
 
@@ -444,6 +448,10 @@ public class PurchasesWrapper {
 
     public static void invalidateCustomerInfoCache() {
         CommonKt.invalidateCustomerInfoCache();
+    }
+
+    public static void overridePreferredUILocale(String locale) {
+        CommonKt.overridePreferredLocale(locale);
     }
 
     public static void setAttributes(String jsonAttributes) {

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -93,6 +93,8 @@ public class PurchasesWrapper {
                              String dangerousSettingsJSON,
                              String entitlementVerificationMode,
                              boolean pendingTransactionsForPrepaidPlansEnabled,
+                             boolean diagnosticsEnabled,
+                             boolean automaticDeviceIdentifierCollectionEnabled,
                              String preferredUILocaleOverride) {
         PurchasesWrapper.gameObject = gameObject;
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
@@ -100,10 +102,8 @@ public class PurchasesWrapper {
         DangerousSettings dangerousSettings = getDangerousSettingsFromJSON(dangerousSettingsJSON);
         CommonKt.configure(UnityPlayer.currentActivity, apiKey, appUserId, purchasesAreCompletedBy, platformInfo, store,
                 dangerousSettings, shouldShowInAppMessagesAutomatically, entitlementVerificationMode,
-                pendingTransactionsForPrepaidPlansEnabled,
-                null, // diagnosticsEnabled
-                null, // automaticDeviceIdentifierCollectionEnabled
-                preferredUILocaleOverride);
+                pendingTransactionsForPrepaidPlansEnabled, diagnosticsEnabled,
+                automaticDeviceIdentifierCollectionEnabled, preferredUILocaleOverride);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(listener);
     }
 

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -81,7 +81,8 @@ purchasesAreCompletedBy:(NSString *)purchasesAreCompletedBy
  userDefaultsSuiteName:(nullable NSString *)userDefaultsSuiteName
  dangerousSettingsJson:(NSString *)dangerousSettingsJson
  shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
- entitlementVerificationMode:(nullable NSString *)entitlementVerificationMode {
+ entitlementVerificationMode:(nullable NSString *)entitlementVerificationMode
+ preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride {
     self.products = nil;
     self.gameObject = nil;
 
@@ -108,7 +109,10 @@ purchasesAreCompletedBy:(NSString *)purchasesAreCompletedBy
                      storeKitVersion:storeKitVersion
                    dangerousSettings:dangerousSettings
 shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
-                    verificationMode:entitlementVerificationMode];
+                    verificationMode:entitlementVerificationMode
+                  diagnosticsEnabled:NO
+automaticDeviceIdentifierCollectionEnabled:YES
+                     preferredLocale:preferredUILocaleOverride];
 
     self.gameObject = gameObject;
     [[RCPurchases sharedPurchases] setDelegate:self];
@@ -294,6 +298,10 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
 
 - (void)invalidateCustomerInfoCache {
     [RCCommonFunctionality invalidateCustomerInfoCache];
+}
+
+- (void)overridePreferredUILocale:(nullable NSString *)locale {
+    [RCCommonFunctionality overridePreferredLocale:locale];
 }
 
 - (void)presentCodeRedemptionSheet {
@@ -824,7 +832,8 @@ void _RCSetupPurchases(const char *gameObject,
                        const char *userDefaultsSuiteName,
                        const char *dangerousSettingsJson,
                        const BOOL shouldShowInAppMessagesAutomatically,
-                       const char *entitlementVerificationMode) {
+                       const char *entitlementVerificationMode,
+                       const char *preferredUILocaleOverride) {
     [_RCUnityHelperShared() setupPurchases:convertCString(apiKey)
                                  appUserID:convertCString(appUserID)
                                 gameObject:convertCString(gameObject)
@@ -833,7 +842,8 @@ void _RCSetupPurchases(const char *gameObject,
                      userDefaultsSuiteName:convertCString(userDefaultsSuiteName)
                      dangerousSettingsJson:convertCString(dangerousSettingsJson)
       shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
-               entitlementVerificationMode:convertCString(entitlementVerificationMode)];
+               entitlementVerificationMode:convertCString(entitlementVerificationMode)
+                 preferredUILocaleOverride:convertCString(preferredUILocaleOverride)];
 }
 
 void _RCGetStorefront() {
@@ -961,6 +971,10 @@ void _RCCheckTrialOrIntroductoryPriceEligibility(const char *productIdentifiersJ
 
 void _RCInvalidateCustomerInfoCache() {
     [_RCUnityHelperShared() invalidateCustomerInfoCache];
+}
+
+void _RCOverridePreferredUILocale(const char *locale) {
+    [_RCUnityHelperShared() overridePreferredUILocale:convertCString(locale)];
 }
 
 void _RCPresentCodeRedemptionSheet() {

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -82,6 +82,8 @@ purchasesAreCompletedBy:(NSString *)purchasesAreCompletedBy
  dangerousSettingsJson:(NSString *)dangerousSettingsJson
  shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
  entitlementVerificationMode:(nullable NSString *)entitlementVerificationMode
+ diagnosticsEnabled:(BOOL)diagnosticsEnabled
+ automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollectionEnabled
  preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride {
     self.products = nil;
     self.gameObject = nil;
@@ -110,8 +112,8 @@ purchasesAreCompletedBy:(NSString *)purchasesAreCompletedBy
                    dangerousSettings:dangerousSettings
 shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
                     verificationMode:entitlementVerificationMode
-                  diagnosticsEnabled:NO
-automaticDeviceIdentifierCollectionEnabled:YES
+                  diagnosticsEnabled:diagnosticsEnabled
+automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
                      preferredLocale:preferredUILocaleOverride];
 
     self.gameObject = gameObject;
@@ -833,6 +835,8 @@ void _RCSetupPurchases(const char *gameObject,
                        const char *dangerousSettingsJson,
                        const BOOL shouldShowInAppMessagesAutomatically,
                        const char *entitlementVerificationMode,
+                       const BOOL diagnosticsEnabled,
+                       const BOOL automaticDeviceIdentifierCollectionEnabled,
                        const char *preferredUILocaleOverride) {
     [_RCUnityHelperShared() setupPurchases:convertCString(apiKey)
                                  appUserID:convertCString(appUserID)
@@ -843,6 +847,8 @@ void _RCSetupPurchases(const char *gameObject,
                      dangerousSettingsJson:convertCString(dangerousSettingsJson)
       shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically
                entitlementVerificationMode:convertCString(entitlementVerificationMode)
+                        diagnosticsEnabled:diagnosticsEnabled
+automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
                  preferredUILocaleOverride:convertCString(preferredUILocaleOverride)];
 }
 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -195,6 +195,7 @@ public partial class Purchases : MonoBehaviour
             purchasesConfiguration.PurchasesAreCompletedBy, purchasesConfiguration.StoreKitVersion, purchasesConfiguration.UserDefaultsSuiteName,
             purchasesConfiguration.UseAmazon, dangerousSettings, purchasesConfiguration.ShouldShowInAppMessagesAutomatically,
             purchasesConfiguration.EntitlementVerificationMode, purchasesConfiguration.PendingTransactionsForPrepaidPlansEnabled,
+            purchasesConfiguration.DiagnosticsEnabled, purchasesConfiguration.AutomaticDeviceIdentifierCollectionEnabled,
             purchasesConfiguration.PreferredUILocaleOverride);
     }
 

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -194,7 +194,8 @@ public partial class Purchases : MonoBehaviour
         _wrapper.Setup(gameObject.name, purchasesConfiguration.ApiKey, purchasesConfiguration.AppUserId,
             purchasesConfiguration.PurchasesAreCompletedBy, purchasesConfiguration.StoreKitVersion, purchasesConfiguration.UserDefaultsSuiteName,
             purchasesConfiguration.UseAmazon, dangerousSettings, purchasesConfiguration.ShouldShowInAppMessagesAutomatically,
-            purchasesConfiguration.EntitlementVerificationMode, purchasesConfiguration.PendingTransactionsForPrepaidPlansEnabled);
+            purchasesConfiguration.EntitlementVerificationMode, purchasesConfiguration.PendingTransactionsForPrepaidPlansEnabled,
+            purchasesConfiguration.PreferredUILocaleOverride);
     }
 
     private bool IsAndroidEmulator()
@@ -831,7 +832,15 @@ public partial class Purchases : MonoBehaviour
         _wrapper.CheckTrialOrIntroductoryPriceEligibility(products);
     }
 
-    ///
+    /// <summary>
+    /// Overrides the preferred UI locale (e.g. "de_DE") used by RevenueCat UI components like Paywalls,
+    /// instead of the device locale. Pass null to clear the override.
+    /// </summary>
+    public void OverridePreferredUILocale(string locale)
+    {
+        _wrapper.OverridePreferredUILocale(locale);
+    }
+
     /// <summary>
     /// Invalidates the cache for customer information.
     /// </summary>

--- a/RevenueCat/Scripts/PurchasesConfiguration.cs
+++ b/RevenueCat/Scripts/PurchasesConfiguration.cs
@@ -33,10 +33,11 @@ public partial class Purchases
         public readonly bool ShouldShowInAppMessagesAutomatically;
         public readonly EntitlementVerificationMode EntitlementVerificationMode;
         public readonly bool PendingTransactionsForPrepaidPlansEnabled;
+        public readonly string PreferredUILocaleOverride;
 
         private PurchasesConfiguration(string apiKey, string appUserId, PurchasesAreCompletedBy purchasesAreCompletedBy, string userDefaultsSuiteName,
-            bool useAmazon, DangerousSettings dangerousSettings, StoreKitVersion storeKitVersion, bool shouldShowInAppMessagesAutomatically, 
-            EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled)
+            bool useAmazon, DangerousSettings dangerousSettings, StoreKitVersion storeKitVersion, bool shouldShowInAppMessagesAutomatically,
+            EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
         {
             ApiKey = apiKey;
             AppUserId = appUserId;
@@ -48,6 +49,7 @@ public partial class Purchases
             ShouldShowInAppMessagesAutomatically = shouldShowInAppMessagesAutomatically;
             EntitlementVerificationMode = entitlementVerificationMode;
             PendingTransactionsForPrepaidPlansEnabled = pendingTransactionsForPrepaidPlansEnabled;
+            PreferredUILocaleOverride = preferredUILocaleOverride;
         }
 
         /// <summary>
@@ -81,6 +83,7 @@ public partial class Purchases
             private bool _shouldShowInAppMessagesAutomatically;
             private EntitlementVerificationMode _entitlementVerificationMode;
             private bool _pendingTransactionsForPrepaidPlansEnabled;
+            private string _preferredUILocaleOverride;
 
             private Builder(string apiKey)
             {
@@ -96,8 +99,8 @@ public partial class Purchases
             {
                 _dangerousSettings = _dangerousSettings ?? new DangerousSettings(true);
                 return new PurchasesConfiguration(_apiKey, _appUserId, _purchasesAreCompletedBy, _userDefaultsSuiteName,
-                    _useAmazon, _dangerousSettings, _storeKitVersion, _shouldShowInAppMessagesAutomatically, 
-                    _entitlementVerificationMode, _pendingTransactionsForPrepaidPlansEnabled);
+                    _useAmazon, _dangerousSettings, _storeKitVersion, _shouldShowInAppMessagesAutomatically,
+                    _entitlementVerificationMode, _pendingTransactionsForPrepaidPlansEnabled, _preferredUILocaleOverride);
             }
 
             public Builder SetAppUserId(string appUserId)
@@ -155,6 +158,16 @@ public partial class Purchases
                 return this;
             }
 
+            /// <summary>
+            /// Sets a preferred UI locale override (e.g. "de_DE") used by RevenueCat UI components like Paywalls,
+            /// instead of the device locale. Useful for apps with in-app language switching.
+            /// </summary>
+            public Builder SetPreferredUILocaleOverride(string preferredUILocaleOverride)
+            {
+                _preferredUILocaleOverride = preferredUILocaleOverride;
+                return this;
+            }
+
         }
 
         public override string ToString()
@@ -169,7 +182,8 @@ public partial class Purchases
                 $"{nameof(StoreKitVersion)}: {StoreKitVersion}\n" +
                 $"{nameof(ShouldShowInAppMessagesAutomatically)}: {ShouldShowInAppMessagesAutomatically}\n" +
                 $"{nameof(EntitlementVerificationMode)}: {EntitlementVerificationMode}\n" +
-                $"{nameof(PendingTransactionsForPrepaidPlansEnabled)}: {PendingTransactionsForPrepaidPlansEnabled}\n";
+                $"{nameof(PendingTransactionsForPrepaidPlansEnabled)}: {PendingTransactionsForPrepaidPlansEnabled}\n" +
+                $"{nameof(PreferredUILocaleOverride)}: {PreferredUILocaleOverride}\n";
         }
     }
 }

--- a/RevenueCat/Scripts/PurchasesConfiguration.cs
+++ b/RevenueCat/Scripts/PurchasesConfiguration.cs
@@ -33,11 +33,14 @@ public partial class Purchases
         public readonly bool ShouldShowInAppMessagesAutomatically;
         public readonly EntitlementVerificationMode EntitlementVerificationMode;
         public readonly bool PendingTransactionsForPrepaidPlansEnabled;
+        public readonly bool DiagnosticsEnabled;
+        public readonly bool AutomaticDeviceIdentifierCollectionEnabled;
         public readonly string PreferredUILocaleOverride;
 
         private PurchasesConfiguration(string apiKey, string appUserId, PurchasesAreCompletedBy purchasesAreCompletedBy, string userDefaultsSuiteName,
             bool useAmazon, DangerousSettings dangerousSettings, StoreKitVersion storeKitVersion, bool shouldShowInAppMessagesAutomatically,
-            EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+            EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled,
+            bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride)
         {
             ApiKey = apiKey;
             AppUserId = appUserId;
@@ -49,6 +52,8 @@ public partial class Purchases
             ShouldShowInAppMessagesAutomatically = shouldShowInAppMessagesAutomatically;
             EntitlementVerificationMode = entitlementVerificationMode;
             PendingTransactionsForPrepaidPlansEnabled = pendingTransactionsForPrepaidPlansEnabled;
+            DiagnosticsEnabled = diagnosticsEnabled;
+            AutomaticDeviceIdentifierCollectionEnabled = automaticDeviceIdentifierCollectionEnabled;
             PreferredUILocaleOverride = preferredUILocaleOverride;
         }
 
@@ -83,6 +88,8 @@ public partial class Purchases
             private bool _shouldShowInAppMessagesAutomatically;
             private EntitlementVerificationMode _entitlementVerificationMode;
             private bool _pendingTransactionsForPrepaidPlansEnabled;
+            private bool _diagnosticsEnabled;
+            private bool _automaticDeviceIdentifierCollectionEnabled = true;
             private string _preferredUILocaleOverride;
 
             private Builder(string apiKey)
@@ -100,7 +107,8 @@ public partial class Purchases
                 _dangerousSettings = _dangerousSettings ?? new DangerousSettings(true);
                 return new PurchasesConfiguration(_apiKey, _appUserId, _purchasesAreCompletedBy, _userDefaultsSuiteName,
                     _useAmazon, _dangerousSettings, _storeKitVersion, _shouldShowInAppMessagesAutomatically,
-                    _entitlementVerificationMode, _pendingTransactionsForPrepaidPlansEnabled, _preferredUILocaleOverride);
+                    _entitlementVerificationMode, _pendingTransactionsForPrepaidPlansEnabled, _diagnosticsEnabled,
+                    _automaticDeviceIdentifierCollectionEnabled, _preferredUILocaleOverride);
             }
 
             public Builder SetAppUserId(string appUserId)
@@ -159,8 +167,29 @@ public partial class Purchases
             }
 
             /// <summary>
+            /// Enabling diagnostics will send some performance and debugging information from the SDK to RevenueCat servers.
+            /// No personal identifiable information is collected. Disabled by default.
+            /// </summary>
+            public Builder SetDiagnosticsEnabled(bool diagnosticsEnabled)
+            {
+                _diagnosticsEnabled = diagnosticsEnabled;
+                return this;
+            }
+
+            /// <summary>
+            /// Allows collection of device identifiers when setting an attribution network ID (e.g. SetAdjustID),
+            /// as required by some attribution networks. Identifiers are only collected if the user has not limited
+            /// ad tracking on their device. Enabled by default.
+            /// </summary>
+            public Builder SetAutomaticDeviceIdentifierCollectionEnabled(bool automaticDeviceIdentifierCollectionEnabled)
+            {
+                _automaticDeviceIdentifierCollectionEnabled = automaticDeviceIdentifierCollectionEnabled;
+                return this;
+            }
+
+            /// <summary>
             /// Sets a preferred UI locale override (e.g. "de_DE") used by RevenueCat UI components like Paywalls,
-            /// instead of the device locale. Useful for apps with in-app language switching.
+            /// instead of the device locale.
             /// </summary>
             public Builder SetPreferredUILocaleOverride(string preferredUILocaleOverride)
             {
@@ -183,6 +212,8 @@ public partial class Purchases
                 $"{nameof(ShouldShowInAppMessagesAutomatically)}: {ShouldShowInAppMessagesAutomatically}\n" +
                 $"{nameof(EntitlementVerificationMode)}: {EntitlementVerificationMode}\n" +
                 $"{nameof(PendingTransactionsForPrepaidPlansEnabled)}: {PendingTransactionsForPrepaidPlansEnabled}\n" +
+                $"{nameof(DiagnosticsEnabled)}: {DiagnosticsEnabled}\n" +
+                $"{nameof(AutomaticDeviceIdentifierCollectionEnabled)}: {AutomaticDeviceIdentifierCollectionEnabled}\n" +
                 $"{nameof(PreferredUILocaleOverride)}: {PreferredUILocaleOverride}\n";
         }
     }

--- a/RevenueCat/Scripts/PurchasesWrapper.cs
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs
@@ -6,12 +6,12 @@ public interface IPurchasesWrapper
 {
     void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
-        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled);
+        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride);
 
     void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
         bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
-        bool pendingTransactionsForPrepaidPlansEnabled);
+        bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride);
 
     void GetStorefront();
     void GetProducts(string[] productIdentifiers, string type = "subs");
@@ -52,6 +52,7 @@ public interface IPurchasesWrapper
     bool IsConfigured();
     void CheckTrialOrIntroductoryPriceEligibility(string[] productIdentifiers);
     void InvalidateCustomerInfoCache();
+    void OverridePreferredUILocale(string locale);
     void PresentCodeRedemptionSheet();
     void RecordPurchase(string productID);
     void SetSimulatesAskToBuyInSandbox(bool enabled);

--- a/RevenueCat/Scripts/PurchasesWrapper.cs
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs
@@ -6,12 +6,14 @@ public interface IPurchasesWrapper
 {
     void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
-        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride);
+        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled,
+        bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride);
 
     void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
         bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
-        bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride);
+        bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled, bool automaticDeviceIdentifierCollectionEnabled,
+        string preferredUILocaleOverride);
 
     void GetStorefront();
     void GetProducts(string[] productIdentifiers, string type = "subs");

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -89,19 +89,22 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
 
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy, Purchases.StoreKitVersion storeKitVersion,
         string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson, bool shouldShowInAppMessagesAutomatically,
-        bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+        bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled, bool automaticDeviceIdentifierCollectionEnabled,
+        string preferredUILocaleOverride)
     {
         Setup(gameObject, apiKey, appUserId, purchasesAreCompletedBy, storeKitVersion, userDefaultsSuiteName, useAmazon,
             dangerousSettingsJson, shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled,
-            preferredUILocaleOverride);
+            diagnosticsEnabled, automaticDeviceIdentifierCollectionEnabled, preferredUILocaleOverride);
     }
 
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy, Purchases.StoreKitVersion storeKitVersion,
         string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson, bool shouldShowInAppMessagesAutomatically,
-        Purchases.EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+        Purchases.EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled,
+        bool diagnosticsEnabled, bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride)
     {
         CallPurchases("setup", apiKey, appUserId, gameObject, purchasesAreCompletedBy.Name(), userDefaultsSuiteName, useAmazon, shouldShowInAppMessagesAutomatically,
-            dangerousSettingsJson, entitlementVerificationMode.Name(), pendingTransactionsForPrepaidPlansEnabled, preferredUILocaleOverride);
+            dangerousSettingsJson, entitlementVerificationMode.Name(), pendingTransactionsForPrepaidPlansEnabled, diagnosticsEnabled,
+            automaticDeviceIdentifierCollectionEnabled, preferredUILocaleOverride);
     }
 
     public void RestorePurchases()

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -89,18 +89,19 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
 
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy, Purchases.StoreKitVersion storeKitVersion,
         string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson, bool shouldShowInAppMessagesAutomatically,
-        bool pendingTransactionsForPrepaidPlansEnabled)
+        bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
     {
         Setup(gameObject, apiKey, appUserId, purchasesAreCompletedBy, storeKitVersion, userDefaultsSuiteName, useAmazon,
-            dangerousSettingsJson, shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled);
+            dangerousSettingsJson, shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled,
+            preferredUILocaleOverride);
     }
 
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy, Purchases.StoreKitVersion storeKitVersion,
         string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson, bool shouldShowInAppMessagesAutomatically,
-        Purchases.EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled)
+        Purchases.EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
     {
         CallPurchases("setup", apiKey, appUserId, gameObject, purchasesAreCompletedBy.Name(), userDefaultsSuiteName, useAmazon, shouldShowInAppMessagesAutomatically,
-            dangerousSettingsJson, entitlementVerificationMode.Name(), pendingTransactionsForPrepaidPlansEnabled);
+            dangerousSettingsJson, entitlementVerificationMode.Name(), pendingTransactionsForPrepaidPlansEnabled, preferredUILocaleOverride);
     }
 
     public void RestorePurchases()
@@ -211,6 +212,11 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
     public void InvalidateCustomerInfoCache()
     {
         CallPurchases("invalidateCustomerInfoCache");
+    }
+
+    public void OverridePreferredUILocale(string locale)
+    {
+        CallPurchases("overridePreferredUILocale", locale);
     }
 
     public void PresentCodeRedemptionSheet()

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs
@@ -7,14 +7,14 @@ public partial class Purchases
     {
         public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
             Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
-            bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled)
+            bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
         {
         }
 
         public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
             Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
             bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
-            bool pendingTransactionsForPrepaidPlansEnabled)
+            bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
         {
         }
 
@@ -133,6 +133,10 @@ public partial class Purchases
         }
 
         public void InvalidateCustomerInfoCache()
+        {
+        }
+
+        public void OverridePreferredUILocale(string locale)
         {
         }
 

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs
@@ -7,14 +7,16 @@ public partial class Purchases
     {
         public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
             Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
-            bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+            bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled,
+            bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride)
         {
         }
 
         public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
             Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
             bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
-            bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+            bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled, bool automaticDeviceIdentifierCollectionEnabled,
+            string preferredUILocaleOverride)
         {
         }
 

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -11,24 +11,28 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     private static extern void _RCSetupPurchases(string gameObject, string apiKey, string appUserId, string purchasesAreCompletedBy,
                                                  string storeKitVersion, string userDefaultsSuiteName,
                                                  string dangerousSettingsJson, bool shouldShowInAppMessagesAutomatically,
-                                                 string entitlementVerificationMode, string preferredUILocaleOverride);
+                                                 string entitlementVerificationMode, bool diagnosticsEnabled,
+                                                 bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride);
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
-        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled,
+        bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride)
     {
         Setup(gameObject, apiKey, appUserId, purchasesAreCompletedBy, storeKitVersion,
             userDefaultsSuiteName, useAmazon, dangerousSettingsJson, shouldShowInAppMessagesAutomatically,
-            Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled, preferredUILocaleOverride);
+            Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled, diagnosticsEnabled,
+            automaticDeviceIdentifierCollectionEnabled, preferredUILocaleOverride);
     }
 
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
         bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
-        bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
+        bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled, bool automaticDeviceIdentifierCollectionEnabled,
+        string preferredUILocaleOverride)
     {
         _RCSetupPurchases(gameObject, apiKey, appUserId, purchasesAreCompletedBy.Name(), storeKitVersion.Name(),
             userDefaultsSuiteName, dangerousSettingsJson, shouldShowInAppMessagesAutomatically, entitlementVerificationMode.Name(),
-            preferredUILocaleOverride);
+            diagnosticsEnabled, automaticDeviceIdentifierCollectionEnabled, preferredUILocaleOverride);
     }
 
     [DllImport("__Internal")]

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -11,23 +11,24 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     private static extern void _RCSetupPurchases(string gameObject, string apiKey, string appUserId, string purchasesAreCompletedBy,
                                                  string storeKitVersion, string userDefaultsSuiteName,
                                                  string dangerousSettingsJson, bool shouldShowInAppMessagesAutomatically,
-                                                 string entitlementVerificationMode);
+                                                 string entitlementVerificationMode, string preferredUILocaleOverride);
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
-        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled)
+        bool shouldShowInAppMessagesAutomatically, bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
     {
-        Setup(gameObject, apiKey, appUserId, purchasesAreCompletedBy, storeKitVersion, 
-            userDefaultsSuiteName, useAmazon, dangerousSettingsJson, shouldShowInAppMessagesAutomatically, 
-            Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled);
+        Setup(gameObject, apiKey, appUserId, purchasesAreCompletedBy, storeKitVersion,
+            userDefaultsSuiteName, useAmazon, dangerousSettingsJson, shouldShowInAppMessagesAutomatically,
+            Purchases.EntitlementVerificationMode.Disabled, pendingTransactionsForPrepaidPlansEnabled, preferredUILocaleOverride);
     }
 
     public void Setup(string gameObject, string apiKey, string appUserId, Purchases.PurchasesAreCompletedBy purchasesAreCompletedBy,
         Purchases.StoreKitVersion storeKitVersion, string userDefaultsSuiteName, bool useAmazon, string dangerousSettingsJson,
         bool shouldShowInAppMessagesAutomatically, Purchases.EntitlementVerificationMode entitlementVerificationMode,
-        bool pendingTransactionsForPrepaidPlansEnabled)
+        bool pendingTransactionsForPrepaidPlansEnabled, string preferredUILocaleOverride)
     {
         _RCSetupPurchases(gameObject, apiKey, appUserId, purchasesAreCompletedBy.Name(), storeKitVersion.Name(),
-            userDefaultsSuiteName, dangerousSettingsJson, shouldShowInAppMessagesAutomatically, entitlementVerificationMode.Name());
+            userDefaultsSuiteName, dangerousSettingsJson, shouldShowInAppMessagesAutomatically, entitlementVerificationMode.Name(),
+            preferredUILocaleOverride);
     }
 
     [DllImport("__Internal")]
@@ -238,6 +239,13 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
     public void InvalidateCustomerInfoCache()
     {
         _RCInvalidateCustomerInfoCache();
+    }
+
+    [DllImport("__Internal")]
+    private static extern void _RCOverridePreferredUILocale(string locale);
+    public void OverridePreferredUILocale(string locale)
+    {
+        _RCOverridePreferredUILocale(locale);
     }
 
     [DllImport("__Internal")]

--- a/Subtester/Assets/Tester/Scripts/Screens/ToolsScreen.cs
+++ b/Subtester/Assets/Tester/Scripts/Screens/ToolsScreen.cs
@@ -51,6 +51,14 @@ namespace RevenueCat.Tester.Screens
                 Log($"simulatesAskToBuyInSandbox = {_simulatesAskToBuy}");
             });
 
+            var localeField = AddTextField("Preferred UI Locale", "e.g. es_ES", "es_ES");
+            AddSecondaryButton("Override Preferred UI Locale", () =>
+            {
+                var locale = string.IsNullOrEmpty(localeField.value) ? null : localeField.value;
+                Purchases.OverridePreferredUILocale(locale);
+                Log($"OverridePreferredUILocale({locale ?? "null"})");
+            });
+
             AddSecondaryButton("Present Code Redemption Sheet", () =>
             {
                 Log("Presenting code redemption sheet...");


### PR DESCRIPTION
Adds preferred UI locale override support for parity with the other hybrid SDKs. Also exposes the existing `diagnosticsEnabled` and `automaticDeviceIdentifierCollectionEnabled` configure options. All map to PHC APIs already present in 18.18.0.

Also adds the override option to Subtester.


Part of SDK-4390.

[Screen_recording_20260702_162203.webm](https://github.com/user-attachments/assets/26247efb-b57a-4bdc-ba7c-7823223f7096)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and configure plumbing to existing PHC 18.18.0 behavior; disabling automatic device ID collection is the main privacy-sensitive knob integrators might change.
> 
> **Overview**
> Exposes three RevenueCat Hybrid Common options on the Unity SDK for parity with other hybrid SDKs: **diagnostics**, **automatic device identifier collection**, and **preferred UI locale**.
> 
> **Configuration:** `PurchasesConfiguration.Builder` gains `SetDiagnosticsEnabled`, `SetAutomaticDeviceIdentifierCollectionEnabled` (defaults to enabled), and `SetPreferredUILocaleOverride`. `Configure` forwards these into native `setup` on Android (`CommonKt.configure`) and iOS (`RCPurchases configureWithAPIKey:…`).
> 
> **Runtime locale:** Adds `Purchases.OverridePreferredUILocale` (pass `null` to clear), plumbed through Android/iOS wrappers to `overridePreferredLocale` on PHC.
> 
> Integration API tests and Subtester’s Tools screen were updated to exercise the new APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703a6a31d6b8ba3103281660de0776979d85a34f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->