### PR TITLE
chore: bump fastlane-plugin-revenuecat_internal to unblock hybrid bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: c970fb6d9b93cb7e9f0e4924ff845f1414240aee
+  revision: 9b928b6ca92e965ecb7d63edb810e9343975f3de
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
### Motivation
Hybrid version bumps crash in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass`, because the plugin looked up a removed `bc8` key in purchases-android's `libs.versions.toml`.

### Summary
- Bump the pinned `fastlane-plugin-revenuecat_internal` revision to `main` HEAD, which includes the fix (RevenueCat/fastlane-plugin-revenuecat_internal#145).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only tooling dependency bump with no runtime SDK or app code changes.
> 
> **Overview**
> Pins **`fastlane-plugin-revenuecat_internal`** to a newer git revision in **`Gemfile.lock`** (`c970fb6` → `9b928b6`), pulling in the upstream fix for hybrid release automation.
> 
> That update stops **`update_hybrids_versions_file`** from failing with `undefined method 'captures' for nil:NilClass` when the plugin still expected a removed `bc8` entry in purchases-android’s **`libs.versions.toml`** (RevenueCat/fastlane-plugin-revenuecat_internal#145).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f94be0150eeea6e9be16ac8f28518a777aa94b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->