### PR TITLE
Add IOSPaywallPresentationStyle.FormSheet for iPad paywall presentation

### DIFF
--- a/IntegrationTests/Assets/APITests/PaywallOptionsAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PaywallOptionsAPITests.cs
@@ -108,6 +108,29 @@ namespace DefaultNamespace
             PaywallOptions positional3 = new PaywallOptions(offering, true);
             PaywallOptions positional4 = new PaywallOptions(offering, true, PaywallPresentationConfiguration.FullScreen);
 
+            // Test iOS presentation styles, including FormSheet (small centered modal on iPad)
+            IOSPaywallPresentationStyle iosFullScreen = IOSPaywallPresentationStyle.FullScreen;
+            IOSPaywallPresentationStyle iosSheet = IOSPaywallPresentationStyle.Sheet;
+            IOSPaywallPresentationStyle iosFormSheet = IOSPaywallPresentationStyle.FormSheet;
+            AndroidPaywallPresentationStyle androidFullScreen = AndroidPaywallPresentationStyle.FullScreen;
+
+            // Test per-platform presentationConfiguration with an iOS-only style (Android stays default)
+            PaywallOptions options13 = new PaywallOptions(
+                presentationConfiguration: new PaywallPresentationConfiguration(
+                    ios: IOSPaywallPresentationStyle.FormSheet
+                )
+            );
+
+            // Test per-platform presentationConfiguration specifying both platforms
+            PaywallOptions options14 = new PaywallOptions(
+                offering: offering,
+                displayCloseButton: true,
+                presentationConfiguration: new PaywallPresentationConfiguration(
+                    ios: IOSPaywallPresentationStyle.FormSheet,
+                    android: AndroidPaywallPresentationStyle.FullScreen
+                )
+            );
+
             // Test CustomVariableValue factory methods
             CustomVariableValue stringValue = CustomVariableValue.String("test");
             CustomVariableValue numberValue = CustomVariableValue.Number(42);

--- a/RevenueCatUI/Plugins/iOS/RevenueCatUI.m
+++ b/RevenueCatUI/Plugins/iOS/RevenueCatUI.m
@@ -16,6 +16,7 @@ static NSString *const kRCUIOptionOfferingIdentifier = @"offeringIdentifier";
 static NSString *const kRCUIOptionDisplayCloseButton = @"displayCloseButton";
 static NSString *const kRCUIOptionPresentedOfferingContext = @"presentedOfferingContext";
 static NSString *const kRCUIOptionCustomVariables = @"customVariables";
+static NSString *const kRCUIOptionPresentationMode = @"presentationMode";
 
 static NSString *RCUIStringFromCString(const char *string) {
     if (string == NULL) {
@@ -130,10 +131,17 @@ static id RCUIJSONObjectFromJSONString(NSString *jsonString) {
     return obj;
 }
 
-static NSMutableDictionary *RCUICreateOptionsDictionary(NSString *offeringIdentifier, NSString *presentedOfferingContextJson, BOOL displayCloseButton, BOOL useFullScreenPresentation, NSString *customVariablesJson) {
+static NSMutableDictionary *RCUICreateOptionsDictionary(NSString *offeringIdentifier, NSString *presentedOfferingContextJson, BOOL displayCloseButton, BOOL useFullScreenPresentation, NSString *presentationMode, NSString *customVariablesJson) {
     NSMutableDictionary *options = [NSMutableDictionary new];
     options[kRCUIOptionDisplayCloseButton] = @(displayCloseButton);
+    // Legacy boolean, kept for backwards compatibility with PurchasesHybridCommon versions
+    // that predate `presentationMode`. When both are present, `presentationMode` takes precedence.
     options[@"useFullScreenPresentation"] = @(useFullScreenPresentation);
+
+    // Preferred presentation control. Ignored by older PurchasesHybridCommon versions.
+    if (presentationMode.length > 0) {
+        options[kRCUIOptionPresentationMode] = presentationMode;
+    }
 
     if (offeringIdentifier.length > 0) {
         options[kRCUIOptionOfferingIdentifier] = offeringIdentifier;
@@ -220,6 +228,7 @@ static void RCUIPresentPaywallInternal(NSString *offeringIdentifier,
                                        NSString *presentedOfferingContextJson,
                                        BOOL displayCloseButton,
                                        BOOL useFullScreenPresentation,
+                                       NSString *presentationMode,
                                        NSString *customVariablesJson,
                                        BOOL hasPaywallListener,
                                        RCUIPaywallEventCallback eventCallback,
@@ -235,7 +244,7 @@ static void RCUIPresentPaywallInternal(NSString *offeringIdentifier,
                 proxy.delegate = paywallDelegate;
             }
 
-            NSMutableDictionary *options = RCUICreateOptionsDictionary(offeringIdentifier, presentedOfferingContextJson, displayCloseButton, useFullScreenPresentation, customVariablesJson);
+            NSMutableDictionary *options = RCUICreateOptionsDictionary(offeringIdentifier, presentedOfferingContextJson, displayCloseButton, useFullScreenPresentation, presentationMode, customVariablesJson);
 
             [proxy presentPaywallWithOptions:options
                         purchaseLogicBridge:nil
@@ -257,6 +266,7 @@ static void RCUIPresentPaywallIfNeededInternal(NSString *requiredEntitlementIden
                                                NSString *presentedOfferingContextJson,
                                                BOOL displayCloseButton,
                                                BOOL useFullScreenPresentation,
+                                               NSString *presentationMode,
                                                NSString *customVariablesJson,
                                                BOOL hasPaywallListener,
                                                RCUIPaywallEventCallback eventCallback,
@@ -271,7 +281,7 @@ static void RCUIPresentPaywallIfNeededInternal(NSString *requiredEntitlementIden
                 proxy.delegate = paywallDelegate;
             }
 
-            NSMutableDictionary *options = RCUICreateOptionsDictionary(offeringIdentifier, presentedOfferingContextJson, displayCloseButton, useFullScreenPresentation, customVariablesJson);
+            NSMutableDictionary *options = RCUICreateOptionsDictionary(offeringIdentifier, presentedOfferingContextJson, displayCloseButton, useFullScreenPresentation, presentationMode, customVariablesJson);
             options[kRCUIOptionRequiredEntitlementIdentifier] = requiredEntitlementIdentifier;
 
             [proxy presentPaywallIfNeededWithOptions:options
@@ -289,15 +299,16 @@ static void RCUIPresentPaywallIfNeededInternal(NSString *requiredEntitlementIden
     });
 }
 
-void rcui_presentPaywall(const char *offeringIdentifier, const char *presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, const char *customVariablesJson, bool hasPaywallListener, RCUIPaywallEventCallback eventCallback, RCUIPaywallResultCallback callback) {
+void rcui_presentPaywall(const char *offeringIdentifier, const char *presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, const char *presentationMode, const char *customVariablesJson, bool hasPaywallListener, RCUIPaywallEventCallback eventCallback, RCUIPaywallResultCallback callback) {
     if (!RCUIEnsureReady(callback)) {
         return;
     }
 
     NSString *offering = RCUIStringFromCString(offeringIdentifier);
     NSString *contextJson = RCUIStringFromCString(presentedOfferingContextJson);
+    NSString *presentationModeString = RCUIStringFromCString(presentationMode);
     NSString *customVarsJson = RCUIStringFromCString(customVariablesJson);
-    RCUIPresentPaywallInternal(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, customVarsJson, hasPaywallListener ? YES : NO, eventCallback, callback);
+    RCUIPresentPaywallInternal(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, presentationModeString, customVarsJson, hasPaywallListener ? YES : NO, eventCallback, callback);
 }
 
 void rcui_presentPaywallIfNeeded(const char *requiredEntitlementIdentifier,
@@ -305,6 +316,7 @@ void rcui_presentPaywallIfNeeded(const char *requiredEntitlementIdentifier,
                                  const char *presentedOfferingContextJson,
                                  bool displayCloseButton,
                                  bool useFullScreenPresentation,
+                                 const char *presentationMode,
                                  const char *customVariablesJson,
                                  bool hasPaywallListener,
                                  RCUIPaywallEventCallback eventCallback,
@@ -316,14 +328,15 @@ void rcui_presentPaywallIfNeeded(const char *requiredEntitlementIdentifier,
     NSString *entitlement = RCUIStringFromCString(requiredEntitlementIdentifier);
     NSString *offering = RCUIStringFromCString(offeringIdentifier);
     NSString *contextJson = RCUIStringFromCString(presentedOfferingContextJson);
+    NSString *presentationModeString = RCUIStringFromCString(presentationMode);
     NSString *customVarsJson = RCUIStringFromCString(customVariablesJson);
 
     if (entitlement.length == 0) {
-        RCUIPresentPaywallInternal(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, customVarsJson, hasPaywallListener ? YES : NO, eventCallback, callback);
+        RCUIPresentPaywallInternal(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, presentationModeString, customVarsJson, hasPaywallListener ? YES : NO, eventCallback, callback);
         return;
     }
 
-    RCUIPresentPaywallIfNeededInternal(entitlement, offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, customVarsJson, hasPaywallListener ? YES : NO, eventCallback, callback);
+    RCUIPresentPaywallIfNeededInternal(entitlement, offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, presentationModeString, customVarsJson, hasPaywallListener ? YES : NO, eventCallback, callback);
 }
 
 // MARK: - Purchase Logic Support
@@ -365,6 +378,7 @@ void rcui_presentPaywallWithPurchaseLogic(const char *offeringIdentifier,
                                           const char *presentedOfferingContextJson,
                                           bool displayCloseButton,
                                           bool useFullScreenPresentation,
+                                          const char *presentationMode,
                                           const char *customVariablesJson,
                                           RCUIPurchaseLogicPurchaseCallback purchaseCallback,
                                           RCUIPurchaseLogicRestoreCallback restoreCallback,
@@ -377,6 +391,7 @@ void rcui_presentPaywallWithPurchaseLogic(const char *offeringIdentifier,
 
     NSString *offering = RCUIStringFromCString(offeringIdentifier);
     NSString *contextJson = RCUIStringFromCString(presentedOfferingContextJson);
+    NSString *presentationModeString = RCUIStringFromCString(presentationMode);
     NSString *customVarsJson = RCUIStringFromCString(customVariablesJson);
 
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -390,7 +405,7 @@ void rcui_presentPaywallWithPurchaseLogic(const char *offeringIdentifier,
                 proxy.delegate = paywallDelegate;
             }
 
-            NSMutableDictionary *options = RCUICreateOptionsDictionary(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, customVarsJson);
+            NSMutableDictionary *options = RCUICreateOptionsDictionary(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, presentationModeString, customVarsJson);
 
             [proxy presentPaywallWithOptions:options
                         purchaseLogicBridge:bridge
@@ -413,6 +428,7 @@ void rcui_presentPaywallIfNeededWithPurchaseLogic(const char *requiredEntitlemen
                                                    const char *presentedOfferingContextJson,
                                                    bool displayCloseButton,
                                                    bool useFullScreenPresentation,
+                                                   const char *presentationMode,
                                                    const char *customVariablesJson,
                                                    RCUIPurchaseLogicPurchaseCallback purchaseCallback,
                                                    RCUIPurchaseLogicRestoreCallback restoreCallback,
@@ -426,11 +442,12 @@ void rcui_presentPaywallIfNeededWithPurchaseLogic(const char *requiredEntitlemen
     NSString *entitlement = RCUIStringFromCString(requiredEntitlementIdentifier);
     NSString *offering = RCUIStringFromCString(offeringIdentifier);
     NSString *contextJson = RCUIStringFromCString(presentedOfferingContextJson);
+    NSString *presentationModeString = RCUIStringFromCString(presentationMode);
     NSString *customVarsJson = RCUIStringFromCString(customVariablesJson);
 
     if (entitlement.length == 0) {
         rcui_presentPaywallWithPurchaseLogic(offeringIdentifier, presentedOfferingContextJson,
-                                             displayCloseButton, useFullScreenPresentation, customVariablesJson, purchaseCallback, restoreCallback, hasPaywallListener, eventCallback, resultCallback);
+                                             displayCloseButton, useFullScreenPresentation, presentationMode, customVariablesJson, purchaseCallback, restoreCallback, hasPaywallListener, eventCallback, resultCallback);
         return;
     }
 
@@ -445,7 +462,7 @@ void rcui_presentPaywallIfNeededWithPurchaseLogic(const char *requiredEntitlemen
                 proxy.delegate = paywallDelegate;
             }
 
-            NSMutableDictionary *options = RCUICreateOptionsDictionary(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, customVarsJson);
+            NSMutableDictionary *options = RCUICreateOptionsDictionary(offering, contextJson, displayCloseButton ? YES : NO, useFullScreenPresentation ? YES : NO, presentationModeString, customVarsJson);
             options[kRCUIOptionRequiredEntitlementIdentifier] = entitlement;
 
             [proxy presentPaywallIfNeededWithOptions:options

--- a/RevenueCatUI/Scripts/PaywallPresentationConfiguration.cs
+++ b/RevenueCatUI/Scripts/PaywallPresentationConfiguration.cs
@@ -12,8 +12,17 @@ namespace RevenueCatUI
 
         /// <summary>
         /// Presents the paywall as a modal sheet. This is the default iOS behavior.
+        /// On iPad this covers most of the screen; use <see cref="FormSheet"/> for a smaller, centered modal.
         /// </summary>
         public static readonly IOSPaywallPresentationStyle Sheet = new IOSPaywallPresentationStyle("sheet");
+
+        /// <summary>
+        /// Presents the paywall as a form sheet: a smaller, centered modal on iPad.
+        /// On iPhone this renders the same as <see cref="Sheet"/> (the standard bottom sheet).
+        /// Requires a PurchasesHybridCommon version that supports the `presentationMode` option;
+        /// on older versions it falls back to <see cref="Sheet"/>.
+        /// </summary>
+        public static readonly IOSPaywallPresentationStyle FormSheet = new IOSPaywallPresentationStyle("formSheet");
 
         internal string Value { get; }
 

--- a/RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs
+++ b/RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs
@@ -13,10 +13,10 @@ namespace RevenueCatUI.Platforms
         private delegate void PurchaseLogicRestoreCallback(string requestId);
         private delegate void PaywallEventCallback(string eventName, string payloadJson);
 
-        [DllImport("__Internal")] private static extern void rcui_presentPaywall(string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string customVariablesJson, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback cb);
-        [DllImport("__Internal")] private static extern void rcui_presentPaywallIfNeeded(string requiredEntitlementIdentifier, string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string customVariablesJson, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback cb);
-        [DllImport("__Internal")] private static extern void rcui_presentPaywallWithPurchaseLogic(string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string customVariablesJson, PurchaseLogicPurchaseCallback purchaseCallback, PurchaseLogicRestoreCallback restoreCallback, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback resultCallback);
-        [DllImport("__Internal")] private static extern void rcui_presentPaywallIfNeededWithPurchaseLogic(string requiredEntitlementIdentifier, string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string customVariablesJson, PurchaseLogicPurchaseCallback purchaseCallback, PurchaseLogicRestoreCallback restoreCallback, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback resultCallback);
+        [DllImport("__Internal")] private static extern void rcui_presentPaywall(string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string presentationMode, string customVariablesJson, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback cb);
+        [DllImport("__Internal")] private static extern void rcui_presentPaywallIfNeeded(string requiredEntitlementIdentifier, string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string presentationMode, string customVariablesJson, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback cb);
+        [DllImport("__Internal")] private static extern void rcui_presentPaywallWithPurchaseLogic(string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string presentationMode, string customVariablesJson, PurchaseLogicPurchaseCallback purchaseCallback, PurchaseLogicRestoreCallback restoreCallback, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback resultCallback);
+        [DllImport("__Internal")] private static extern void rcui_presentPaywallIfNeededWithPurchaseLogic(string requiredEntitlementIdentifier, string offeringIdentifier, string presentedOfferingContextJson, bool displayCloseButton, bool useFullScreenPresentation, string presentationMode, string customVariablesJson, PurchaseLogicPurchaseCallback purchaseCallback, PurchaseLogicRestoreCallback restoreCallback, bool hasPaywallListener, PaywallEventCallback eventCallback, PaywallResultCallback resultCallback);
 
         private static TaskCompletionSource<PaywallResult> s_current;
 
@@ -34,6 +34,7 @@ namespace RevenueCatUI.Platforms
             {
                 var presentedOfferingContextJson = options?.PresentedOfferingContext?.ToJsonString();
                 var useFullScreen = options?.PresentationConfiguration?.IOS == IOSPaywallPresentationStyle.FullScreen;
+                var presentationMode = options?.PresentationConfiguration?.IOS?.Value;
                 var customVariablesJson = options?.CustomVariablesToJsonString();
                 var hasPaywallListener = options?.Listener != null;
                 if (hasPaywallListener)
@@ -48,6 +49,7 @@ namespace RevenueCatUI.Platforms
                         presentedOfferingContextJson,
                         options.DisplayCloseButton,
                         useFullScreen,
+                        presentationMode,
                         customVariablesJson,
                         OnPerformPurchase,
                         OnPerformRestore,
@@ -57,7 +59,7 @@ namespace RevenueCatUI.Platforms
                 }
                 else
                 {
-                    rcui_presentPaywall(options?.OfferingIdentifier, presentedOfferingContextJson, options?.DisplayCloseButton ?? false, useFullScreen, customVariablesJson, hasPaywallListener, OnPaywallEvent, OnResult);
+                    rcui_presentPaywall(options?.OfferingIdentifier, presentedOfferingContextJson, options?.DisplayCloseButton ?? false, useFullScreen, presentationMode, customVariablesJson, hasPaywallListener, OnPaywallEvent, OnResult);
                 }
             }
             catch (Exception e)
@@ -85,6 +87,7 @@ namespace RevenueCatUI.Platforms
             {
                 var presentedOfferingContextJson = options?.PresentedOfferingContext?.ToJsonString();
                 var useFullScreen = options?.PresentationConfiguration?.IOS == IOSPaywallPresentationStyle.FullScreen;
+                var presentationMode = options?.PresentationConfiguration?.IOS?.Value;
                 var customVariablesJson = options?.CustomVariablesToJsonString();
                 var hasPaywallListener = options?.Listener != null;
                 if (hasPaywallListener)
@@ -100,6 +103,7 @@ namespace RevenueCatUI.Platforms
                         presentedOfferingContextJson,
                         options.DisplayCloseButton,
                         useFullScreen,
+                        presentationMode,
                         customVariablesJson,
                         OnPerformPurchase,
                         OnPerformRestore,
@@ -109,7 +113,7 @@ namespace RevenueCatUI.Platforms
                 }
                 else
                 {
-                    rcui_presentPaywallIfNeeded(requiredEntitlementIdentifier, options?.OfferingIdentifier, presentedOfferingContextJson, options?.DisplayCloseButton ?? true, useFullScreen, customVariablesJson, hasPaywallListener, OnPaywallEvent, OnResult);
+                    rcui_presentPaywallIfNeeded(requiredEntitlementIdentifier, options?.OfferingIdentifier, presentedOfferingContextJson, options?.DisplayCloseButton ?? true, useFullScreen, presentationMode, customVariablesJson, hasPaywallListener, OnPaywallEvent, OnResult);
                 }
             }
             catch (Exception e)

--- a/Subtester/Assets/Tester/Scripts/Screens/PaywallScreen.cs
+++ b/Subtester/Assets/Tester/Scripts/Screens/PaywallScreen.cs
@@ -144,6 +144,15 @@ namespace RevenueCat.Tester.Screens
                 LogPaywallResult("Paywall (full screen)", result);
             });
 
+            AddButton("Present Paywall Form Sheet", async () =>
+            {
+                var offering = await GetOfferingByIdAsync(_offeringIdField.value);
+                Log("Presenting paywall form sheet...");
+                var result = await PaywallsPresenter.Present(BuildOptions(offering: offering,
+                    presentationConfiguration: new PaywallPresentationConfiguration(ios: IOSPaywallPresentationStyle.FormSheet)));
+                LogPaywallResult("Paywall (form sheet)", result);
+            });
+
             AddButton("Present Paywall (With Listener)", async () =>
             {
                 var offering = await GetOfferingByIdAsync(_offeringIdField.value);


### PR DESCRIPTION
## Summary

Adds an `IOSPaywallPresentationStyle.FormSheet` option so hybrid apps can present the paywall as a small, centered modal on iPad instead of the large `pageSheet` (reported in #976). On iPhone `FormSheet` renders the same as `Sheet`, so it is safe to set unconditionally in cross-platform code.

This is the **Unity half** of RevenueCat/purchases-hybrid-common#1726, which added the `presentationMode` option to `PaywallProxy` on the native iOS side. That PR is now merged and shipped in PHC 18.23.0, and `main` has since bumped the pins to 18.25.0, so this branch no longer needs a follow-up pin bump.

## How it works

The selected iOS style is now threaded to the native layer as a new `presentationMode` string, **alongside** the existing `useFullScreenPresentation` bool. Both are sent, so behavior is backwards and forwards compatible:

- On a PurchasesHybridCommon without `presentationMode` support: `FullScreen`/`Sheet` keep working via the bool, and `FormSheet` degrades harmlessly to the default sheet.
- On the currently pinned PHC 18.25.0 (contains #1726): `presentationMode` takes precedence and `FormSheet` works.

Verified on an iPad Pro 12.9" simulator: `FormSheet` presents a small centered modal (~581x637 pt), the default presents a page sheet (~706x937 pt), and `FullScreen` still covers the screen. See the Validation section below for the full comparison.

| iOS style | iPhone | iPad |
|---|---|---|
| `FullScreen` | full screen | full screen |
| `Sheet` (default) | standard bottom sheet | large near-full sheet (#976) |
| `FormSheet` (new) | standard bottom sheet (same as `Sheet`) | small centered modal (the fix) |

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: #995 (purchases-unity, draft)
- Branch: `facundo/unity-paywall-formsheet`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context) for the original implementation; Claude Code (Opus 5, 1M context) for the 2026-07-27 rebase
- Session source: current conversation
- Generated: 2026-07-21; last updated 2026-07-27
- Context document version: 2

## Goal

Wire the iOS-only `presentationMode` option (added natively in purchases-hybrid-common#1726) through the Unity SDK by exposing `IOSPaywallPresentationStyle.FormSheet`, so Unity apps can render the small centered iPad modal (fixes #976 for Unity).

## Initial Prompt

Original session: implement the Unity follow-up that surfaces the new `presentationMode` capability from PHC #1726 (verbatim opener: "let's work on unity now, pr is green and approved (don't merge it yet)"). Later: "make sure we have coverage for unity too" and "open a draft PR in unity so we link it to the PHC PR".

2026-07-27 session: resolve the merge conflicts on this PR and get it mergeable (verbatim opener: "Can you fix conflicts here <PR #995 url>?").

## Important Follow-up Prompts

- Established (earlier in the session, on the PHC side) that `presentationMode` is iOS-only and that Unity's presentation API is already platform-split (`IOSPaywallPresentationStyle` vs `AndroidPaywallPresentationStyle`).
- "make sure we have coverage for unity too" — drove the API compile-surface test addition.

## Agent Contribution

Original implementation:

- Traced the Unity presentation path: shared `PaywallsPresenter`/`PaywallOptions`/`PaywallPresentationConfiguration` -> `IOSPaywallPresenter` (`#if UNITY_IOS`) -> P/Invoke -> `RevenueCatUI.m` -> PHC `PaywallProxy`.
- Found the current bridge collapses the style to a `bool useFullScreenPresentation`, which cannot express `formSheet`.
- Added `IOSPaywallPresentationStyle.FormSheet` and threaded the style string as `presentationMode` through all 4 native entry points + helpers, keeping the legacy bool for compatibility.
- Added API compile-surface coverage.

2026-07-27 rebase (this session):

- Rebased onto `origin/main` (`771ffc2`), which had picked up #1001 (PaywallListener). Both PRs widened the same 4 bridge signatures, producing conflicts in `RevenueCatUI.m` and `IOSPaywallPresenter.cs`.
- Resolved by unioning both parameter sets under a single rule: `presentationMode` immediately after `useFullScreenPresentation`; `hasPaywallListener, eventCallback` left in main's position immediately before the result callback. Merged arities: `rcui_presentPaywall` 9, `rcui_presentPaywallIfNeeded` 10, `…WithPurchaseLogic` 11, `…IfNeededWithPurchaseLogic` 12.
- Found and fixed a **silent auto-merge build break**: git cleanly merged both sides' additions to `PaywallOptionsAPITests.cs`, leaving `options12` declared twice in one scope (main's listener test + this PR's FormSheet test). Renumbered this PR's locals to `options13`/`options14`.
- Confirmed PHC #1726 shipped in 18.23.0 and that both the Android and **iOS** pins (`RevenueCatDependencies.xml`, `RevenueCatUIDependencies.xml`: `remoteSwiftPackage` + `iosPod`) are now 18.25.0, so the original "pins must be bumped" caveat is satisfied. Updated the PR summary accordingly.
- Verified the Unity side emits values PHC actually accepts (`"fullScreen"`, `"sheet"`, `"formSheet"`) and that `presentationMode` takes precedence over the legacy bool, by reading PHC #1726's specs.

## Human Decisions

- Token set: `FormSheet` only (rejected also adding `Automatic` — iOS 18+ only, regresses on older iPadOS — and `PageSheet` — redundant with existing `Sheet`).
- Do not merge PHC #1726 yet; open Unity PR as draft and link it. (PHC #1726 has since merged.)

## Key Implementation Decisions

- Decision: send both `useFullScreenPresentation` (bool) and `presentationMode` (string).
  - Rationale: backwards compatible on old PHC (bool still honored, FormSheet degrades to sheet); forwards compatible on PHC >= 18.23.0 (presentationMode wins).
  - Rejected: replace the bool with the string outright (would break FullScreen/Sheet on older PHC).
- Decision: add `FormSheet` only to `IOSPaywallPresentationStyle`.
  - Rationale: the option is iOS-only; the platform-split API keeps it off Android with no conditional compilation in shared code.
- Decision (rebase): keep main's parameter ordering for the listener args rather than normalizing all params into one group.
  - Rationale: minimizes the diff against `main` and keeps #1001's deliberate "listener args immediately before the result callback" convention intact.

## Files / Symbols Touched

- `RevenueCatUI/Scripts/PaywallPresentationConfiguration.cs`
  - Symbols: `IOSPaywallPresentationStyle.FormSheet`
  - Review relevance: the new public API surface + docs.
- `RevenueCatUI/Scripts/Platforms/iOS/IOSPaywallPresenter.cs`
  - Symbols: 4 `rcui_present*` `DllImport`s, `PresentPaywallAsync`, `PresentPaywallIfNeededAsync`
  - Review relevance: `presentationMode` passed alongside the bool and alongside #1001's listener args; positional match with the `.m`.
- `RevenueCatUI/Plugins/iOS/RevenueCatUI.m`
  - Symbols: `RCUICreateOptionsDictionary`, `RCUIPresentPaywallInternal`, `RCUIPresentPaywallIfNeededInternal`, the 4 `rcui_present*` externs, `kRCUIOptionPresentationMode`
  - Review relevance: `presentationMode` threaded through; `options[@"presentationMode"]` set only when non-empty.
- `IntegrationTests/Assets/APITests/PaywallOptionsAPITests.cs`
  - Symbols: `options13`, `options14`
  - Review relevance: compile-surface coverage of `FormSheet` + per-platform config; locals renumbered to avoid collision with #1001's `options12`.

## Dependencies / Config / Migrations

- Depends on purchases-hybrid-common#1726 (native `presentationMode`) — merged, shipped in PHC 18.23.0.
- PHC pins are at 18.25.0 on both platforms after the rebase (Android `androidPackage`, iOS `remoteSwiftPackage` + `iosPod`). No pin change is made by this PR.

## Validation

- Commands run:
  - `git rebase origin/main`: 2 conflicted files, resolved; rebased commit `b22e672`. Post-rebase diff vs `main` is 4 files / +69 -16, identical in shape to the pre-rebase commit (no feature lost).
  - Scripted positional comparison of all 4 `DllImport` <-> ObjC extern pairs, plus every call site of `RCUICreateOptionsDictionary`, `RCUIPresentPaywallInternal`, `RCUIPresentPaywallIfNeededInternal`: all parameters aligned by index; arities 9/10/11/12 as expected.
  - `csc -noconfig -nostdlib -define:UNITY_IOS` over `RevenueCat/Scripts` + `RevenueCatUI/Scripts` + `IntegrationTests/Assets/APITests`, referencing Unity 6000.2.6f2 module assemblies + netstandard 2.1: compiles with no errors introduced by this branch.
  - Same compile against an `origin/main` worktree as a baseline: reproduces exactly one pre-existing `CS0121` in `PaywallsPresenterAPITests.cs:19`, unrelated to this branch.
  - RED/GREEN for the duplicate-local defect: pre-fix source fails with `error CS0128: A local variable or function named 'options12' is already defined in this scope`; post-fix source compiles clean.
  - Sabotage check confirming `IOSPaywallPresenter.cs` is actually inside the `-define:UNITY_IOS` compile (injecting a 10th argument yields `CS1501`), so the clean pass really does verify the merged call sites.
  - `git diff origin/main -- RevenueCatUI/Plugins/iOS/RevenueCatUI.m` filtered for non-`presentationMode` lines: empty, i.e. #1001's listener work is fully preserved.
- Manual verification (iPad Pro 12.9" simulator, iOS 16.4, PHC 18.25.0 via SPM):
  - Unity 6000.2.6f2 iOS export -> `xcodebuild -sdk iphonesimulator` -> installed and launched the Subtester.
  - Compared every presentation style on the same simulator, in landscape (1366x1024 pt). Approximate presented-modal sizes:

    | Button | Style requested | Presented as |
    |---|---|---|
    | Present Paywall | default (no `presentationMode`) | page sheet, ~706 x 937 |
    | Present Paywall (No Close Button) | default (no `presentationMode`) | page sheet, ~706 x 937 |
    | Present Paywall Full Screen | `fullScreen` | edge-to-edge full screen |
    | **Present Paywall Form Sheet** | `presentationMode: "formSheet"` | **~581 x 637, small centered modal** |

    All three styles render distinctly. The two default buttons matching each other is the control: the size delta tracks `presentationMode`, not incidental layout. Full Screen still covering the whole screen is the regression check, i.e. threading the new parameter through did not disturb the existing `useFullScreenPresentation` path. Console confirms the new path ran: `Presenting paywall form sheet...`.
  - Note on geometry: `.pageSheet` is near-full-width on iPad only in portrait. In landscape it is already constrained to roughly half the width, so the form-sheet signal is the smaller box in both dimensions rather than a full-screen-vs-small contrast.
  - This exercises the full chain end to end: C# `IOSPaywallPresentationStyle.FormSheet` -> `DllImport` marshal -> `rcui_presentPaywall` -> `RCUICreateOptionsDictionary` -> PHC `presentationMode` -> UIKit `.formSheet`.
  - Caveat: the test project's products could not be fetched in the simulator (`Error 23 / CONFIGURATION_ERROR`, no StoreKit config), so the form sheet contains an error state rather than rendered paywall content. Modal geometry is unaffected by this: `modalPresentationStyle` is applied at presentation time regardless of whether products load.
- CI:
  - All 12 checks green on `b22e672`, including `build-subtester-ios`, `archive-ios`, `archive-ios-cocoapods`, `build-integration-tests-ios`, `export-package`, and `test-edit-mode`. The iOS jobs are the first and only compile of `RevenueCatUI.m`, so the merged bridge signatures are now compiler-verified end to end.

## Validation Gaps

- `RevenueCatUI.m` cannot be compiled locally — the `@import RevenueCat` / `@import PurchasesHybridCommonUI` Swift modules are unavailable outside the Unity iOS build. Covered by the green `build-subtester-ios` / `archive-ios` jobs.
- The local `csc` setup approximates Unity's compiler and defines; it is not the Unity Editor's own compilation. Superseded by the green `test-edit-mode` job.
- The paywall content itself never rendered: the test project's products could not be fetched in the simulator (`Error 23 / CONFIGURATION_ERROR`, no StoreKit config), so each modal contained an error state. Presentation style is verified; a real paywall rendered inside a form sheet is not.
- Verified on the iOS **simulator** only, in landscape, on one device class (iPad Pro 12.9"). Not run on a physical iPad, not run in portrait, and not run on a small iPad where form-sheet and page-sheet sizes converge.
- Modal sizes above are measured off screenshots, so they are approximate; they are used to distinguish styles, not as exact geometry assertions.

## Review Focus

- Are the 4 `DllImport` signatures positionally aligned with the `rcui_present*` externs in `RevenueCatUI.m`? A mismatch compiles clean on both sides and corrupts arguments only at runtime on device.
- Is sending both the legacy bool and `presentationMode` correct for every style (FullScreen/Sheet/FormSheet/null) on both old and new PHC?
- `IOSPaywallPresentationStyle` is a reference type with singleton statics, so `PresentationConfiguration?.IOS == IOSPaywallPresentationStyle.FullScreen` is reference equality — confirm `FormSheet` correctly leaves `useFullScreenPresentation` false.

## Risks / Reviewer Notes

- Risk: `DllImport` <-> extern signature drift. Not caught by any compiler; fails at runtime on device.
  - Evidence: verified by scripted param-by-param positional comparison of all 4 pairs (arities 9/10/11/12) plus all internal helper call sites.
  - Mitigation: the Subtester iOS build in CI compiles the `.m`; API tests are built as part of it.
- Risk: rebase silently dropping or duplicating part of #1001's listener work.
  - Evidence: the filtered `.m` diff against `origin/main` contains only `presentationMode` lines; the duplicate-`options12` collision was caught and fixed with a RED/GREEN compile.
  - Mitigation: none further needed.

## Non-goals / Out of Scope

- Bumping the PHC version pins (already at 18.25.0 via `main`).
- Android changes (no equivalent concept).
- Subtester UI toggle (optional follow-up).
- The pre-existing `CS0121` ambiguity in `PaywallsPresenterAPITests.cs` (present on `main`).

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>
