### PR TITLE
test: cover custom paywall tracking, ad tracker, and model parsing

### DIFF
--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5982e1cdbdb7404faef3d912f9ace126
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/customer-info-full.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/customer-info-full.json
@@ -1,0 +1,71 @@
+{
+  "entitlements": {
+    "all": {
+      "premium": {
+        "identifier": "premium",
+        "isActive": true,
+        "willRenew": true,
+        "periodType": "NORMAL",
+        "latestPurchaseDateMillis": 1700000000000,
+        "originalPurchaseDateMillis": 1690000000000,
+        "store": "APP_STORE",
+        "productIdentifier": "monthly",
+        "isSandbox": false
+      }
+    },
+    "active": {
+      "premium": {
+        "identifier": "premium",
+        "isActive": true,
+        "willRenew": true,
+        "periodType": "NORMAL",
+        "latestPurchaseDateMillis": 1700000000000,
+        "originalPurchaseDateMillis": 1690000000000,
+        "store": "APP_STORE",
+        "productIdentifier": "monthly",
+        "isSandbox": false
+      }
+    },
+    "verification": "NOT_REQUESTED"
+  },
+  "activeSubscriptions": [
+    "monthly"
+  ],
+  "allPurchasedProductIdentifiers": [
+    "monthly",
+    "lifetime"
+  ],
+  "firstSeenMillis": 1700000000000,
+  "originalAppUserId": "user_1",
+  "requestDateMillis": 1700000000001,
+  "originalPurchaseDateMillis": 1690000000000,
+  "latestExpirationDateMillis": 1720000000000,
+  "managementURL": "https://mgmt",
+  "allExpirationDatesMillis": {
+    "monthly": 1720000000000,
+    "lifetime": 0
+  },
+  "allPurchaseDatesMillis": {
+    "monthly": 1700000000000,
+    "lifetime": 0
+  },
+  "originalApplicationVersion": "1.0",
+  "nonSubscriptionTransactions": [
+    {
+      "transactionIdentifier": "txn_1",
+      "productIdentifier": "lifetime",
+      "purchaseDateMillis": 1700000000000
+    }
+  ],
+  "subscriptionsByProductIdentifier": {
+    "monthly": {
+      "productIdentifier": "monthly",
+      "purchaseDate": "2023-01-01T00:00:00Z",
+      "store": "APP_STORE",
+      "isSandbox": false,
+      "periodType": "NORMAL",
+      "isActive": true,
+      "willRenew": true
+    }
+  }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/customer-info-full.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/customer-info-full.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a9256b23db244a3fb510dbb51cee33ce
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-known-category.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-known-category.json
@@ -1,0 +1,9 @@
+{
+  "title": "Monthly",
+  "identifier": "monthly",
+  "description": "Monthly access",
+  "price": 9.99,
+  "priceString": "$9.99",
+  "currencyCode": "USD",
+  "productCategory": "SUBSCRIPTION"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-known-category.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-known-category.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dc667e3ab7be4e87b8431fa93f8c1019
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-unrecognized-category.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-unrecognized-category.json
@@ -1,0 +1,9 @@
+{
+  "title": "Lifetime",
+  "identifier": "lifetime",
+  "description": "Lifetime access",
+  "price": 99.99,
+  "priceString": "$99.99",
+  "currencyCode": "USD",
+  "productCategory": "UNRECOGNIZED"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-unrecognized-category.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/store-product-unrecognized-category.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9a4e14f71acc4c1ca8ea41983fb43af1
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-full.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-full.json
@@ -1,0 +1,54 @@
+{
+  "id": "monthly:base",
+  "storeProductId": "monthly",
+  "productId": "monthly",
+  "tags": [
+    "tag1"
+  ],
+  "isBasePlan": true,
+  "billingPeriod": {
+    "unit": "MONTH",
+    "value": 1,
+    "iso8601": "P1M"
+  },
+  "isPrepaid": false,
+  "pricingPhases": [
+    {
+      "billingPeriod": {
+        "unit": "MONTH",
+        "value": 1,
+        "iso8601": "P1M"
+      },
+      "recurrenceMode": "INFINITE_RECURRING",
+      "billingCycleCount": 0,
+      "price": {
+        "formatted": "$9.99",
+        "amountMicros": 9990000,
+        "currencyCode": "USD"
+      },
+      "offerPaymentMode": "SINGLE_PAYMENT"
+    }
+  ],
+  "fullPricePhase": {
+    "billingPeriod": {
+      "unit": "MONTH",
+      "value": 1,
+      "iso8601": "P1M"
+    },
+    "recurrenceMode": "INFINITE_RECURRING",
+    "billingCycleCount": 0,
+    "price": {
+      "formatted": "$9.99",
+      "amountMicros": 9990000,
+      "currencyCode": "USD"
+    },
+    "offerPaymentMode": "SINGLE_PAYMENT"
+  },
+  "presentedOfferingContext": {
+    "offeringIdentifier": "default"
+  },
+  "installmentsInfo": {
+    "commitmentPaymentsCount": 3,
+    "renewalCommitmentPaymentsCount": 1
+  }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-full.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-full.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 668c4bb7b993434287d13be22bbd0b63
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-minimal.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-minimal.json
@@ -1,0 +1,13 @@
+{
+  "id": "monthly:base",
+  "storeProductId": "monthly",
+  "productId": "monthly",
+  "tags": [],
+  "isBasePlan": true,
+  "billingPeriod": {
+    "unit": "MONTH",
+    "value": 1,
+    "iso8601": "P1M"
+  },
+  "isPrepaid": false
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-minimal.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-minimal.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17f04d4eab744eba86e08a38c55607ac
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-unrecognized-enums.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-unrecognized-enums.json
@@ -1,0 +1,28 @@
+{
+  "id": "monthly:base",
+  "storeProductId": "monthly",
+  "productId": "monthly",
+  "tags": [],
+  "isBasePlan": true,
+  "billingPeriod": {
+    "unit": "MONTH",
+    "value": 1,
+    "iso8601": "P1M"
+  },
+  "isPrepaid": false,
+  "fullPricePhase": {
+    "billingPeriod": {
+      "unit": "MONTH",
+      "value": 1,
+      "iso8601": "P1M"
+    },
+    "recurrenceMode": "BOGUS",
+    "billingCycleCount": 0,
+    "price": {
+      "formatted": "$9.99",
+      "amountMicros": 9990000,
+      "currencyCode": "USD"
+    },
+    "offerPaymentMode": "BOGUS"
+  }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-unrecognized-enums.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-option-unrecognized-enums.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 69529197d68743fc9763f3ef380fd215
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-price-large-amount.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-price-large-amount.json
@@ -1,0 +1,5 @@
+{
+  "formatted": "$4,294.97",
+  "amountMicros": 4294970000,
+  "currencyCode": "USD"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-price-large-amount.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/subscription-price-large-amount.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ee385f49a7ac492a81c9a02bd913d50a
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/virtual-currencies.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/virtual-currencies.json
@@ -1,0 +1,16 @@
+{
+  "all": {
+    "COIN": {
+      "balance": 120,
+      "name": "Coins",
+      "code": "COIN",
+      "serverDescription": "Earned in game"
+    },
+    "GEM": {
+      "balance": 4,
+      "name": "Gems",
+      "code": "GEM",
+      "serverDescription": null
+    }
+  }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/virtual-currencies.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/virtual-currencies.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f86a94c2dcbd4186a352cf0ff8ea74d8
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-error.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-error.json
@@ -1,0 +1,10 @@
+{
+  "result": "ERROR",
+  "error": {
+    "message": "There was a credentials issue. Check the underlying error for more details.",
+    "code": 11,
+    "underlyingErrorMessage": "Backend rejected",
+    "readableErrorCode": "INVALID_CREDENTIALS",
+    "readable_error_code": "INVALID_CREDENTIALS"
+  }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-error.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-error.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76d06d1bacaf42f4b267121f81f9e88b
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-expired.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-expired.json
@@ -1,0 +1,4 @@
+{
+  "result": "EXPIRED",
+  "obfuscatedEmail": "a***@b.com"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-expired.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-expired.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b69d0b1fe2647b4a714d47dcc595492
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-invalid-token.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-invalid-token.json
@@ -1,0 +1,3 @@
+{
+  "result": "INVALID_TOKEN"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-invalid-token.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-invalid-token.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 37288a8309d94e188d26a7e8d288aa38
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-other-user.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-other-user.json
@@ -1,0 +1,3 @@
+{
+  "result": "PURCHASE_BELONGS_TO_OTHER_USER"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-other-user.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-other-user.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 514b31eb0ed34b2ab2c4360491d85a1a
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-success.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-success.json
@@ -1,0 +1,29 @@
+{
+  "result": "SUCCESS",
+  "customerInfo": {
+    "entitlements": {
+      "all": {},
+      "active": {},
+      "verification": "NOT_REQUESTED"
+    },
+    "activeSubscriptions": [],
+    "allPurchasedProductIdentifiers": [],
+    "latestExpirationDate": null,
+    "latestExpirationDateMillis": null,
+    "firstSeen": "2023-11-14T22:13:20.000Z",
+    "firstSeenMillis": 1700000000000,
+    "originalAppUserId": "user_1",
+    "requestDate": "2023-11-14T22:13:20.001Z",
+    "requestDateMillis": 1700000000001,
+    "allExpirationDates": {},
+    "allExpirationDatesMillis": {},
+    "allPurchaseDates": {},
+    "allPurchaseDatesMillis": {},
+    "originalApplicationVersion": null,
+    "originalPurchaseDate": null,
+    "originalPurchaseDateMillis": null,
+    "managementURL": null,
+    "nonSubscriptionTransactions": [],
+    "subscriptionsByProductIdentifier": {}
+  }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-success.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-success.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64fb48f417904c56990f465635dfbb98
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-unrecognized.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-unrecognized.json
@@ -1,0 +1,3 @@
+{
+  "result": "SOMETHING_ELSE"
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-unrecognized.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/web-purchase-redemption-unrecognized.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8aecb3d59a7b4eda9af887a2fda16e51
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -1,39 +1,23 @@
 using System;
+using System.IO;
 using NUnit.Framework;
 using RevenueCat.SimpleJSON;
+using UnityEngine;
 
 namespace RevenueCat.Tests
 {
     public class JsonModelTests
     {
-        /// purchases-hybrid-common's CustomerInfo.map() (Android) / CustomerInfo.dictionary (iOS)
-        /// for a user with no purchases. Every optional field is present as an explicit null rather
-        /// than absent: Android's Map.convertToJson() maps Kotlin null to JSONObject.NULL and the
-        /// iOS mappers use NSNull(). SimpleJSON treats a null node and an absent node alike, but
-        /// the fixture spells them out so it matches what actually ships.
-        private const string MinimalCustomerInfoJson =
-            "{\"entitlements\":{\"all\":{},\"active\":{},\"verification\":\"NOT_REQUESTED\"}," +
-            "\"activeSubscriptions\":[],\"allPurchasedProductIdentifiers\":[]," +
-            "\"latestExpirationDate\":null,\"latestExpirationDateMillis\":null," +
-            "\"firstSeen\":\"2023-11-14T22:13:20.000Z\",\"firstSeenMillis\":1700000000000," +
-            "\"originalAppUserId\":\"user_1\"," +
-            "\"requestDate\":\"2023-11-14T22:13:20.001Z\",\"requestDateMillis\":1700000000001," +
-            "\"allExpirationDates\":{},\"allExpirationDatesMillis\":{}," +
-            "\"allPurchaseDates\":{},\"allPurchaseDatesMillis\":{}," +
-            "\"originalApplicationVersion\":null," +
-            "\"originalPurchaseDate\":null,\"originalPurchaseDateMillis\":null," +
-            "\"managementURL\":null,\"nonSubscriptionTransactions\":[]," +
-            "\"subscriptionsByProductIdentifier\":{}}";
+        private static JSONNode LoadFixture(string filename)
+        {
+            var path = Path.Combine(Application.dataPath, "Tests", "EditMode", "JsonModelFixtures", filename);
+            return JSONNode.Parse(File.ReadAllText(path));
+        }
 
         [Test]
         public void VirtualCurrenciesParsesCurrenciesByCode()
         {
-            var response = JSONNode.Parse(
-                "{\"all\":{" +
-                "\"COIN\":{\"balance\":120,\"name\":\"Coins\",\"code\":\"COIN\",\"serverDescription\":\"Earned in game\"}," +
-                "\"GEM\":{\"balance\":4,\"name\":\"Gems\",\"code\":\"GEM\",\"serverDescription\":null}" +
-                "}}"
-            );
+            var response = LoadFixture("virtual-currencies.json");
 
             var virtualCurrencies = new Purchases.VirtualCurrencies(response);
 
@@ -48,9 +32,7 @@ namespace RevenueCat.Tests
         [Test]
         public void SubscriptionPriceSupportsValuesAboveInt32Range()
         {
-            var response = JSONNode.Parse(
-                "{\"formatted\":\"$4,294.97\",\"amountMicros\":4294970000,\"currencyCode\":\"USD\"}"
-            );
+            var response = LoadFixture("subscription-price-large-amount.json");
 
             var price = new Purchases.SubscriptionOption.Price(response);
 
@@ -60,11 +42,7 @@ namespace RevenueCat.Tests
         [Test]
         public void StoreProductParsesKnownProductCategory()
         {
-            var response = JSONNode.Parse(
-                "{\"title\":\"Monthly\",\"identifier\":\"monthly\",\"description\":\"Monthly access\"," +
-                "\"price\":9.99,\"priceString\":\"$9.99\",\"currencyCode\":\"USD\"," +
-                "\"productCategory\":\"SUBSCRIPTION\"}"
-            );
+            var response = LoadFixture("store-product-known-category.json");
 
             var product = new Purchases.StoreProduct(response);
 
@@ -77,11 +55,7 @@ namespace RevenueCat.Tests
             // "UNRECOGNIZED" is deliberately synthetic: StoreProductMapper can only send
             // SUBSCRIPTION, NON_SUBSCRIPTION or UNKNOWN. This pins down the parser's fallback for
             // a category added natively before Unity knows about it.
-            var response = JSONNode.Parse(
-                "{\"title\":\"Lifetime\",\"identifier\":\"lifetime\",\"description\":\"Lifetime access\"," +
-                "\"price\":99.99,\"priceString\":\"$99.99\",\"currencyCode\":\"USD\"," +
-                "\"productCategory\":\"UNRECOGNIZED\"}"
-            );
+            var response = LoadFixture("store-product-unrecognized-category.json");
 
             var product = new Purchases.StoreProduct(response);
 
@@ -94,33 +68,7 @@ namespace RevenueCat.Tests
         [Test]
         public void CustomerInfoParsesFullPayload()
         {
-            var response = JSONNode.Parse(
-                "{\"entitlements\":{" +
-                "\"all\":{\"premium\":{\"identifier\":\"premium\",\"isActive\":true,\"willRenew\":true," +
-                "\"periodType\":\"NORMAL\",\"latestPurchaseDateMillis\":1700000000000," +
-                "\"originalPurchaseDateMillis\":1690000000000,\"store\":\"APP_STORE\"," +
-                "\"productIdentifier\":\"monthly\",\"isSandbox\":false}}," +
-                "\"active\":{\"premium\":{\"identifier\":\"premium\",\"isActive\":true,\"willRenew\":true," +
-                "\"periodType\":\"NORMAL\",\"latestPurchaseDateMillis\":1700000000000," +
-                "\"originalPurchaseDateMillis\":1690000000000,\"store\":\"APP_STORE\"," +
-                "\"productIdentifier\":\"monthly\",\"isSandbox\":false}}," +
-                "\"verification\":\"NOT_REQUESTED\"}," +
-                "\"activeSubscriptions\":[\"monthly\"]," +
-                "\"allPurchasedProductIdentifiers\":[\"monthly\",\"lifetime\"]," +
-                "\"firstSeenMillis\":1700000000000,\"originalAppUserId\":\"user_1\"," +
-                "\"requestDateMillis\":1700000000001," +
-                "\"originalPurchaseDateMillis\":1690000000000," +
-                "\"latestExpirationDateMillis\":1720000000000," +
-                "\"managementURL\":\"https://mgmt\"," +
-                "\"allExpirationDatesMillis\":{\"monthly\":1720000000000,\"lifetime\":0}," +
-                "\"allPurchaseDatesMillis\":{\"monthly\":1700000000000,\"lifetime\":0}," +
-                "\"originalApplicationVersion\":\"1.0\"," +
-                "\"nonSubscriptionTransactions\":[{\"transactionIdentifier\":\"txn_1\"," +
-                "\"productIdentifier\":\"lifetime\",\"purchaseDateMillis\":1700000000000}]," +
-                "\"subscriptionsByProductIdentifier\":{\"monthly\":{\"productIdentifier\":\"monthly\"," +
-                "\"purchaseDate\":\"2023-01-01T00:00:00Z\",\"store\":\"APP_STORE\",\"isSandbox\":false," +
-                "\"periodType\":\"NORMAL\",\"isActive\":true,\"willRenew\":true}}}"
-            );
+            var response = LoadFixture("customer-info-full.json");
 
             var customerInfo = new Purchases.CustomerInfo(response);
 
@@ -148,21 +96,7 @@ namespace RevenueCat.Tests
         [Test]
         public void SubscriptionOptionParsesFullPayloadWithPricingPhases()
         {
-            const string pricingPhaseJson =
-                "{\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"}," +
-                "\"recurrenceMode\":\"INFINITE_RECURRING\",\"billingCycleCount\":0," +
-                "\"price\":{\"formatted\":\"$9.99\",\"amountMicros\":9990000,\"currencyCode\":\"USD\"}," +
-                "\"offerPaymentMode\":\"SINGLE_PAYMENT\"}";
-
-            var response = JSONNode.Parse(
-                "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
-                "\"tags\":[\"tag1\"],\"isBasePlan\":true," +
-                "\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"},\"isPrepaid\":false," +
-                "\"pricingPhases\":[" + pricingPhaseJson + "]," +
-                "\"fullPricePhase\":" + pricingPhaseJson + "," +
-                "\"presentedOfferingContext\":{\"offeringIdentifier\":\"default\"}," +
-                "\"installmentsInfo\":{\"commitmentPaymentsCount\":3,\"renewalCommitmentPaymentsCount\":1}}"
-            );
+            var response = LoadFixture("subscription-option-full.json");
 
             var option = new Purchases.SubscriptionOption(response);
 
@@ -180,11 +114,7 @@ namespace RevenueCat.Tests
         [Test]
         public void SubscriptionOptionParsesMinimalPayloadWithoutOptionalFields()
         {
-            var response = JSONNode.Parse(
-                "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
-                "\"tags\":[],\"isBasePlan\":true," +
-                "\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"},\"isPrepaid\":false}"
-            );
+            var response = LoadFixture("subscription-option-minimal.json");
 
             var option = new Purchases.SubscriptionOption(response);
 
@@ -202,15 +132,7 @@ namespace RevenueCat.Tests
             // "BOGUS" is deliberately synthetic, like the UNRECOGNIZED category above: it stands in
             // for a recurrenceMode or offerPaymentMode that Android starts sending before Unity
             // knows the name, and pins down the UNKNOWN fallback.
-            var response = JSONNode.Parse(
-                "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
-                "\"tags\":[],\"isBasePlan\":true," +
-                "\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"},\"isPrepaid\":false," +
-                "\"fullPricePhase\":{\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"}," +
-                "\"recurrenceMode\":\"BOGUS\",\"billingCycleCount\":0," +
-                "\"price\":{\"formatted\":\"$9.99\",\"amountMicros\":9990000,\"currencyCode\":\"USD\"}," +
-                "\"offerPaymentMode\":\"BOGUS\"}}"
-            );
+            var response = LoadFixture("subscription-option-unrecognized-enums.json");
 
             var option = new Purchases.SubscriptionOption(response);
 
@@ -231,9 +153,10 @@ namespace RevenueCat.Tests
         [Test]
         public void WebPurchaseRedemptionResultParsesSuccessVariant()
         {
-            var response = JSONNode.Parse(
-                "{\"result\":\"SUCCESS\",\"customerInfo\":" + MinimalCustomerInfoJson + "}"
-            );
+            // The nested CustomerInfo comes from purchases-hybrid-common's CustomerInfo.map()
+            // (Android) / CustomerInfo.dictionary (iOS) for a user with no purchases. Every
+            // optional field is an explicit null, matching the payload that actually ships.
+            var response = LoadFixture("web-purchase-redemption-success.json");
 
             var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
 
@@ -244,16 +167,10 @@ namespace RevenueCat.Tests
         [Test]
         public void WebPurchaseRedemptionResultParsesErrorVariant()
         {
-            var response = JSONNode.Parse(
-                // readableErrorCode is ErrorCode.codeName on iOS and PurchasesErrorCode.name on
-                // Android; both duplicate it under the deprecated readable_error_code. Code 11 is
-                // InvalidCredentialsError, so these are the iOS values for that code.
-                "{\"result\":\"ERROR\",\"error\":{\"message\":\"There was a credentials issue. " +
-                "Check the underlying error for more details.\",\"code\":11," +
-                "\"underlyingErrorMessage\":\"Backend rejected\"," +
-                "\"readableErrorCode\":\"INVALID_CREDENTIALS\"," +
-                "\"readable_error_code\":\"INVALID_CREDENTIALS\"}}"
-            );
+            // readableErrorCode is ErrorCode.codeName on iOS and PurchasesErrorCode.name on
+            // Android; both duplicate it under the deprecated readable_error_code. Code 11 is
+            // InvalidCredentialsError, so these are the iOS values for that code.
+            var response = LoadFixture("web-purchase-redemption-error.json");
 
             var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
 
@@ -264,7 +181,7 @@ namespace RevenueCat.Tests
         [Test]
         public void WebPurchaseRedemptionResultParsesInvalidTokenVariant()
         {
-            var response = JSONNode.Parse("{\"result\":\"INVALID_TOKEN\"}");
+            var response = LoadFixture("web-purchase-redemption-invalid-token.json");
 
             var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
 
@@ -274,7 +191,7 @@ namespace RevenueCat.Tests
         [Test]
         public void WebPurchaseRedemptionResultParsesExpiredVariant()
         {
-            var response = JSONNode.Parse("{\"result\":\"EXPIRED\",\"obfuscatedEmail\":\"a***@b.com\"}");
+            var response = LoadFixture("web-purchase-redemption-expired.json");
 
             var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
 
@@ -286,7 +203,7 @@ namespace RevenueCat.Tests
         [Test]
         public void WebPurchaseRedemptionResultParsesPurchaseBelongsToOtherUserVariant()
         {
-            var response = JSONNode.Parse("{\"result\":\"PURCHASE_BELONGS_TO_OTHER_USER\"}");
+            var response = LoadFixture("web-purchase-redemption-other-user.json");
 
             var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
 
@@ -296,7 +213,7 @@ namespace RevenueCat.Tests
         [Test]
         public void WebPurchaseRedemptionResultThrowsForUnrecognizedResultType()
         {
-            var response = JSONNode.Parse("{\"result\":\"SOMETHING_ELSE\"}");
+            var response = LoadFixture("web-purchase-redemption-unrecognized.json");
 
             Assert.Throws<ArgumentException>(() => Purchases.WebPurchaseRedemptionResult.FromJson(response));
         }

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -6,12 +6,23 @@ namespace RevenueCat.Tests
 {
     public class JsonModelTests
     {
+        /// CustomerInfo.map() / CustomerInfo.dictionary in purchases-hybrid-common 18.29.0 for a
+        /// user with no purchases. Every optional field is present as an explicit null rather than
+        /// absent: Android's Map.convertToJson() maps Kotlin null to JSONObject.NULL and the iOS
+        /// mappers use NSNull(). SimpleJSON treats a null node and an absent node alike, but the
+        /// fixture spells them out so it matches what actually ships.
         private const string MinimalCustomerInfoJson =
-            "{\"entitlements\":{\"all\":{},\"active\":{}}," +
+            "{\"entitlements\":{\"all\":{},\"active\":{},\"verification\":\"NOT_REQUESTED\"}," +
             "\"activeSubscriptions\":[],\"allPurchasedProductIdentifiers\":[]," +
-            "\"firstSeenMillis\":1700000000000,\"originalAppUserId\":\"user_1\"," +
-            "\"requestDateMillis\":1700000000001,\"allExpirationDatesMillis\":{}," +
-            "\"allPurchaseDatesMillis\":{},\"nonSubscriptionTransactions\":[]," +
+            "\"latestExpirationDate\":null,\"latestExpirationDateMillis\":null," +
+            "\"firstSeen\":\"2023-11-14T22:13:20.000Z\",\"firstSeenMillis\":1700000000000," +
+            "\"originalAppUserId\":\"user_1\"," +
+            "\"requestDate\":\"2023-11-14T22:13:20.001Z\",\"requestDateMillis\":1700000000001," +
+            "\"allExpirationDates\":{},\"allExpirationDatesMillis\":{}," +
+            "\"allPurchaseDates\":{},\"allPurchaseDatesMillis\":{}," +
+            "\"originalApplicationVersion\":null," +
+            "\"originalPurchaseDate\":null,\"originalPurchaseDateMillis\":null," +
+            "\"managementURL\":null,\"nonSubscriptionTransactions\":[]," +
             "\"subscriptionsByProductIdentifier\":{}}";
 
         [Test]
@@ -63,6 +74,9 @@ namespace RevenueCat.Tests
         [Test]
         public void StoreProductFallsBackToUnknownProductCategory()
         {
+            // "UNRECOGNIZED" is deliberately synthetic: StoreProductMapper can only send
+            // SUBSCRIPTION, NON_SUBSCRIPTION or UNKNOWN. This pins down the parser's fallback for
+            // a category added natively before Unity knows about it.
             var response = JSONNode.Parse(
                 "{\"title\":\"Lifetime\",\"identifier\":\"lifetime\",\"description\":\"Lifetime access\"," +
                 "\"price\":99.99,\"priceString\":\"$99.99\",\"currencyCode\":\"USD\"," +
@@ -89,7 +103,8 @@ namespace RevenueCat.Tests
                 "\"active\":{\"premium\":{\"identifier\":\"premium\",\"isActive\":true,\"willRenew\":true," +
                 "\"periodType\":\"NORMAL\",\"latestPurchaseDateMillis\":1700000000000," +
                 "\"originalPurchaseDateMillis\":1690000000000,\"store\":\"APP_STORE\"," +
-                "\"productIdentifier\":\"monthly\",\"isSandbox\":false}}}," +
+                "\"productIdentifier\":\"monthly\",\"isSandbox\":false}}," +
+                "\"verification\":\"NOT_REQUESTED\"}," +
                 "\"activeSubscriptions\":[\"monthly\"]," +
                 "\"allPurchasedProductIdentifiers\":[\"monthly\",\"lifetime\"]," +
                 "\"firstSeenMillis\":1700000000000,\"originalAppUserId\":\"user_1\"," +
@@ -184,6 +199,9 @@ namespace RevenueCat.Tests
         [Test]
         public void SubscriptionOptionPricingPhaseFallsBackToUnknownForUnrecognizedEnums()
         {
+            // "BOGUS" is deliberately synthetic, like the UNRECOGNIZED category above: it stands in
+            // for a recurrenceMode or offerPaymentMode that Android starts sending before Unity
+            // knows the name, and pins down the UNKNOWN fallback.
             var response = JSONNode.Parse(
                 "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
                 "\"tags\":[],\"isBasePlan\":true," +
@@ -227,8 +245,14 @@ namespace RevenueCat.Tests
         public void WebPurchaseRedemptionResultParsesErrorVariant()
         {
             var response = JSONNode.Parse(
-                "{\"result\":\"ERROR\",\"error\":{\"message\":\"Redemption failed\",\"code\":11," +
-                "\"underlyingErrorMessage\":\"Backend rejected\",\"readableErrorCode\":\"UNKNOWN_ERROR\"}}"
+                // readableErrorCode is ErrorCode.codeName on iOS and PurchasesErrorCode.name on
+                // Android; both duplicate it under the deprecated readable_error_code. Code 11 is
+                // InvalidCredentialsError, so these are the iOS values for that code.
+                "{\"result\":\"ERROR\",\"error\":{\"message\":\"There was a credentials issue. " +
+                "Check the underlying error for more details.\",\"code\":11," +
+                "\"underlyingErrorMessage\":\"Backend rejected\"," +
+                "\"readableErrorCode\":\"INVALID_CREDENTIALS\"," +
+                "\"readable_error_code\":\"INVALID_CREDENTIALS\"}}"
             );
 
             var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -6,11 +6,11 @@ namespace RevenueCat.Tests
 {
     public class JsonModelTests
     {
-        /// CustomerInfo.map() / CustomerInfo.dictionary in purchases-hybrid-common 18.29.0 for a
-        /// user with no purchases. Every optional field is present as an explicit null rather than
-        /// absent: Android's Map.convertToJson() maps Kotlin null to JSONObject.NULL and the iOS
-        /// mappers use NSNull(). SimpleJSON treats a null node and an absent node alike, but the
-        /// fixture spells them out so it matches what actually ships.
+        /// purchases-hybrid-common's CustomerInfo.map() (Android) / CustomerInfo.dictionary (iOS)
+        /// for a user with no purchases. Every optional field is present as an explicit null rather
+        /// than absent: Android's Map.convertToJson() maps Kotlin null to JSONObject.NULL and the
+        /// iOS mappers use NSNull(). SimpleJSON treats a null node and an absent node alike, but
+        /// the fixture spells them out so it matches what actually ships.
         private const string MinimalCustomerInfoJson =
             "{\"entitlements\":{\"all\":{},\"active\":{},\"verification\":\"NOT_REQUESTED\"}," +
             "\"activeSubscriptions\":[],\"allPurchasedProductIdentifiers\":[]," +

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using RevenueCat.SimpleJSON;
 
@@ -5,6 +6,14 @@ namespace RevenueCat.Tests
 {
     public class JsonModelTests
     {
+        private const string MinimalCustomerInfoJson =
+            "{\"entitlements\":{\"all\":{},\"active\":{}}," +
+            "\"activeSubscriptions\":[],\"allPurchasedProductIdentifiers\":[]," +
+            "\"firstSeenMillis\":1700000000000,\"originalAppUserId\":\"user_1\"," +
+            "\"requestDateMillis\":1700000000001,\"allExpirationDatesMillis\":{}," +
+            "\"allPurchaseDatesMillis\":{},\"nonSubscriptionTransactions\":[]," +
+            "\"subscriptionsByProductIdentifier\":{}}";
+
         [Test]
         public void VirtualCurrenciesParsesCurrenciesByCode()
         {
@@ -66,6 +75,206 @@ namespace RevenueCat.Tests
             Assert.That(product.ProductCategory, Is.EqualTo(Purchases.ProductCategory.UNKNOWN));
             Assert.That(product.DefaultOption, Is.Null);
             Assert.That(product.Discounts, Is.Null);
+        }
+
+        [Test]
+        public void CustomerInfoParsesFullPayload()
+        {
+            var response = JSONNode.Parse(
+                "{\"entitlements\":{" +
+                "\"all\":{\"premium\":{\"identifier\":\"premium\",\"isActive\":true,\"willRenew\":true," +
+                "\"periodType\":\"NORMAL\",\"latestPurchaseDateMillis\":1700000000000," +
+                "\"originalPurchaseDateMillis\":1690000000000,\"store\":\"APP_STORE\"," +
+                "\"productIdentifier\":\"monthly\",\"isSandbox\":false}}," +
+                "\"active\":{\"premium\":{\"identifier\":\"premium\",\"isActive\":true,\"willRenew\":true," +
+                "\"periodType\":\"NORMAL\",\"latestPurchaseDateMillis\":1700000000000," +
+                "\"originalPurchaseDateMillis\":1690000000000,\"store\":\"APP_STORE\"," +
+                "\"productIdentifier\":\"monthly\",\"isSandbox\":false}}}," +
+                "\"activeSubscriptions\":[\"monthly\"]," +
+                "\"allPurchasedProductIdentifiers\":[\"monthly\",\"lifetime\"]," +
+                "\"firstSeenMillis\":1700000000000,\"originalAppUserId\":\"user_1\"," +
+                "\"requestDateMillis\":1700000000001," +
+                "\"originalPurchaseDateMillis\":1690000000000," +
+                "\"latestExpirationDateMillis\":1720000000000," +
+                "\"managementURL\":\"https://mgmt\"," +
+                "\"allExpirationDatesMillis\":{\"monthly\":1720000000000,\"lifetime\":0}," +
+                "\"allPurchaseDatesMillis\":{\"monthly\":1700000000000,\"lifetime\":0}," +
+                "\"originalApplicationVersion\":\"1.0\"," +
+                "\"nonSubscriptionTransactions\":[{\"transactionIdentifier\":\"txn_1\"," +
+                "\"productIdentifier\":\"lifetime\",\"purchaseDateMillis\":1700000000000}]," +
+                "\"subscriptionsByProductIdentifier\":{\"monthly\":{\"productIdentifier\":\"monthly\"," +
+                "\"purchaseDate\":\"2023-01-01T00:00:00Z\",\"store\":\"APP_STORE\",\"isSandbox\":false," +
+                "\"periodType\":\"NORMAL\",\"isActive\":true,\"willRenew\":true}}}"
+            );
+
+            var customerInfo = new Purchases.CustomerInfo(response);
+
+            Assert.That(customerInfo.OriginalAppUserId, Is.EqualTo("user_1"));
+            Assert.That(customerInfo.Entitlements.All["premium"].IsActive, Is.True);
+            Assert.That(customerInfo.Entitlements.Active.ContainsKey("premium"), Is.True);
+            Assert.That(customerInfo.ActiveSubscriptions, Is.EquivalentTo(new[] { "monthly" }));
+            Assert.That(customerInfo.AllPurchasedProductIdentifiers, Has.Count.EqualTo(2));
+            Assert.That(customerInfo.OriginalPurchaseDate, Is.Not.Null);
+            Assert.That(customerInfo.LatestExpirationDate, Is.Not.Null);
+            Assert.That(customerInfo.ManagementURL, Is.EqualTo("https://mgmt"));
+            Assert.That(customerInfo.OriginalApplicationVersion, Is.EqualTo("1.0"));
+            Assert.That(customerInfo.NonSubscriptionTransactions, Has.Count.EqualTo(1));
+            Assert.That(customerInfo.NonSubscriptionTransactions[0].ProductIdentifier, Is.EqualTo("lifetime"));
+            Assert.That(customerInfo.SubscriptionsByProductIdentifier["monthly"].ProductIdentifier,
+                Is.EqualTo("monthly"));
+
+            // A millis value of exactly 0 is indistinguishable from an absent date and is parsed as null.
+            Assert.That(customerInfo.AllExpirationDates["monthly"], Is.Not.Null);
+            Assert.That(customerInfo.AllExpirationDates["lifetime"], Is.Null);
+            Assert.That(customerInfo.AllPurchaseDates["monthly"], Is.Not.Null);
+            Assert.That(customerInfo.AllPurchaseDates["lifetime"], Is.Null);
+        }
+
+        [Test]
+        public void SubscriptionOptionParsesFullPayloadWithPricingPhases()
+        {
+            const string pricingPhaseJson =
+                "{\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"}," +
+                "\"recurrenceMode\":\"INFINITE_RECURRING\",\"billingCycleCount\":0," +
+                "\"price\":{\"formatted\":\"$9.99\",\"amountMicros\":9990000,\"currencyCode\":\"USD\"}," +
+                "\"offerPaymentMode\":\"SINGLE_PAYMENT\"}";
+
+            var response = JSONNode.Parse(
+                "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
+                "\"tags\":[\"tag1\"],\"isBasePlan\":true," +
+                "\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"},\"isPrepaid\":false," +
+                "\"pricingPhases\":[" + pricingPhaseJson + "]," +
+                "\"fullPricePhase\":" + pricingPhaseJson + "," +
+                "\"presentedOfferingContext\":{\"offeringIdentifier\":\"default\"}," +
+                "\"installmentsInfo\":{\"commitmentPaymentsCount\":3,\"renewalCommitmentPaymentsCount\":1}}"
+            );
+
+            var option = new Purchases.SubscriptionOption(response);
+
+            Assert.That(option.Tags, Is.EquivalentTo(new[] { "tag1" }));
+            Assert.That(option.PricingPhases, Has.Length.EqualTo(1));
+            Assert.That(option.FullPricePhase, Is.Not.Null);
+            Assert.That(option.FullPricePhase.RecurrenceMode,
+                Is.EqualTo(Purchases.SubscriptionOption.RecurrenceMode.INFINITE_RECURRING));
+            Assert.That(option.PresentedOfferingContext, Is.Not.Null);
+            Assert.That(option.PresentedOfferingContext.OfferingIdentifier, Is.EqualTo("default"));
+            Assert.That(option.OptionInstallmentsInfo, Is.Not.Null);
+            Assert.That(option.OptionInstallmentsInfo.CommitmentPaymentsCount, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void SubscriptionOptionParsesMinimalPayloadWithoutOptionalFields()
+        {
+            var response = JSONNode.Parse(
+                "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
+                "\"tags\":[],\"isBasePlan\":true," +
+                "\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"},\"isPrepaid\":false}"
+            );
+
+            var option = new Purchases.SubscriptionOption(response);
+
+            Assert.That(option.PricingPhases, Is.Null);
+            Assert.That(option.FullPricePhase, Is.Null);
+            Assert.That(option.FreePhase, Is.Null);
+            Assert.That(option.IntroPhase, Is.Null);
+            Assert.That(option.PresentedOfferingContext, Is.Null);
+            Assert.That(option.OptionInstallmentsInfo, Is.Null);
+        }
+
+        [Test]
+        public void SubscriptionOptionPricingPhaseFallsBackToUnknownForUnrecognizedEnums()
+        {
+            var response = JSONNode.Parse(
+                "{\"id\":\"monthly:base\",\"storeProductId\":\"monthly\",\"productId\":\"monthly\"," +
+                "\"tags\":[],\"isBasePlan\":true," +
+                "\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"},\"isPrepaid\":false," +
+                "\"fullPricePhase\":{\"billingPeriod\":{\"unit\":\"MONTH\",\"value\":1,\"iso8601\":\"P1M\"}," +
+                "\"recurrenceMode\":\"BOGUS\",\"billingCycleCount\":0," +
+                "\"price\":{\"formatted\":\"$9.99\",\"amountMicros\":9990000,\"currencyCode\":\"USD\"}," +
+                "\"offerPaymentMode\":\"BOGUS\"}}"
+            );
+
+            var option = new Purchases.SubscriptionOption(response);
+
+            Assert.That(option.FullPricePhase.RecurrenceMode,
+                Is.EqualTo(Purchases.SubscriptionOption.RecurrenceMode.UNKNOWN));
+            Assert.That(option.FullPricePhase.OfferPaymentMode,
+                Is.EqualTo(Purchases.SubscriptionOption.OfferPaymentMode.UNKNOWN));
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionWrapsRedemptionLink()
+        {
+            var redemption = new Purchases.WebPurchaseRedemption("https://rev.cat/redeem/abc");
+
+            Assert.That(redemption.RedemptionLink, Is.EqualTo("https://rev.cat/redeem/abc"));
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionResultParsesSuccessVariant()
+        {
+            var response = JSONNode.Parse(
+                "{\"result\":\"SUCCESS\",\"customerInfo\":" + MinimalCustomerInfoJson + "}"
+            );
+
+            var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
+
+            Assert.That(result, Is.InstanceOf<Purchases.WebPurchaseRedemptionResult.Success>());
+            Assert.That(((Purchases.WebPurchaseRedemptionResult.Success)result).CustomerInfo, Is.Not.Null);
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionResultParsesErrorVariant()
+        {
+            var response = JSONNode.Parse(
+                "{\"result\":\"ERROR\",\"error\":{\"message\":\"Redemption failed\",\"code\":11," +
+                "\"underlyingErrorMessage\":\"Backend rejected\",\"readableErrorCode\":\"UNKNOWN_ERROR\"}}"
+            );
+
+            var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
+
+            Assert.That(result, Is.InstanceOf<Purchases.WebPurchaseRedemptionResult.RedemptionError>());
+            Assert.That(((Purchases.WebPurchaseRedemptionResult.RedemptionError)result).Error.Code, Is.EqualTo(11));
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionResultParsesInvalidTokenVariant()
+        {
+            var response = JSONNode.Parse("{\"result\":\"INVALID_TOKEN\"}");
+
+            var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
+
+            Assert.That(result, Is.SameAs(Purchases.WebPurchaseRedemptionResult.InvalidToken.Instance));
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionResultParsesExpiredVariant()
+        {
+            var response = JSONNode.Parse("{\"result\":\"EXPIRED\",\"obfuscatedEmail\":\"a***@b.com\"}");
+
+            var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
+
+            Assert.That(result, Is.InstanceOf<Purchases.WebPurchaseRedemptionResult.Expired>());
+            Assert.That(((Purchases.WebPurchaseRedemptionResult.Expired)result).ObfuscatedEmail,
+                Is.EqualTo("a***@b.com"));
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionResultParsesPurchaseBelongsToOtherUserVariant()
+        {
+            var response = JSONNode.Parse("{\"result\":\"PURCHASE_BELONGS_TO_OTHER_USER\"}");
+
+            var result = Purchases.WebPurchaseRedemptionResult.FromJson(response);
+
+            Assert.That(result, Is.SameAs(Purchases.WebPurchaseRedemptionResult.PurchaseBelongsToOtherUser.Instance));
+        }
+
+        [Test]
+        public void WebPurchaseRedemptionResultThrowsForUnrecognizedResultType()
+        {
+            var response = JSONNode.Parse("{\"result\":\"SOMETHING_ELSE\"}");
+
+            Assert.Throws<ArgumentException>(() => Purchases.WebPurchaseRedemptionResult.FromJson(response));
         }
     }
 }

--- a/IntegrationTests/Assets/Tests/EditMode/TrackingTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/TrackingTests.cs
@@ -1,0 +1,261 @@
+using NUnit.Framework;
+using RevenueCat;
+using RevenueCat.SimpleJSON;
+using UnityEngine;
+
+namespace RevenueCat.Tests
+{
+    public class TrackingTests
+    {
+        private GameObject _gameObject;
+        private Purchases _purchases;
+        private PurchasesWrapperSpy _wrapper;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gameObject = new GameObject("RevenueCatTests");
+            _purchases = _gameObject.AddComponent<Purchases>();
+            _wrapper = new PurchasesWrapperSpy();
+            _purchases.SetWrapper(_wrapper);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_gameObject);
+        }
+
+        [Test]
+        public void TrackCustomPaywallImpressionWithoutParametersCreatesEmptyParameters()
+        {
+            _purchases.TrackCustomPaywallImpression();
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackCustomPaywallImpression), 1);
+            var parameters = (Purchases.CustomPaywallImpressionParams)invocation.Arguments[0];
+            Assert.That(parameters.PaywallId, Is.Null);
+            Assert.That(parameters.OfferingId, Is.Null);
+            Assert.That(parameters.Offering, Is.Null);
+        }
+
+        [Test]
+        public void TrackCustomPaywallImpressionWithPaywallIdOnlySetsPaywallIdOnly()
+        {
+            _purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams("paywall_1"));
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackCustomPaywallImpression), 1);
+            var parameters = (Purchases.CustomPaywallImpressionParams)invocation.Arguments[0];
+            Assert.That(parameters.PaywallId, Is.EqualTo("paywall_1"));
+            Assert.That(parameters.OfferingId, Is.Null);
+            Assert.That(parameters.Offering, Is.Null);
+        }
+
+        [Test]
+        public void TrackCustomPaywallImpressionWithOfferingResolvesOfferingIdAndContext()
+        {
+            var offering = CreateOfferingWithPackage();
+
+            _purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams(offering));
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackCustomPaywallImpression), 1);
+            var parameters = (Purchases.CustomPaywallImpressionParams)invocation.Arguments[0];
+            Assert.That(parameters.PaywallId, Is.Null);
+            Assert.That(parameters.Offering, Is.SameAs(offering));
+            Assert.That(parameters.OfferingId, Is.EqualTo(offering.Identifier));
+        }
+
+        [Test]
+        public void CustomPaywallImpressionParamsResolvesPresentedOfferingContextFromFirstPackage()
+        {
+            var offering = CreateOfferingWithPackage();
+
+            var parameters = new Purchases.CustomPaywallImpressionParams(offering);
+
+            Assert.That(parameters.PresentedOfferingContext, Is.Not.Null);
+            Assert.That(parameters.PresentedOfferingContext.OfferingIdentifier, Is.EqualTo("default"));
+        }
+
+        [Test]
+        public void CustomPaywallImpressionParamsHasNullPresentedOfferingContextWhenOfferingHasNoPackages()
+        {
+            var offering = new Purchases.Offering(JSONNode.Parse(
+                "{\"identifier\":\"default\",\"serverDescription\":\"desc\",\"availablePackages\":[]}"));
+
+            var parameters = new Purchases.CustomPaywallImpressionParams(offering);
+
+            Assert.That(parameters.PresentedOfferingContext, Is.Null);
+        }
+
+        [Test]
+        public void TrackCustomPaywallImpressionWithPaywallIdAndOfferingSetsBoth()
+        {
+            var offering = CreateOfferingWithPackage();
+
+            _purchases.TrackCustomPaywallImpression(new Purchases.CustomPaywallImpressionParams("paywall_1", offering));
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackCustomPaywallImpression), 1);
+            var parameters = (Purchases.CustomPaywallImpressionParams)invocation.Arguments[0];
+            Assert.That(parameters.PaywallId, Is.EqualTo("paywall_1"));
+            Assert.That(parameters.OfferingId, Is.EqualTo(offering.Identifier));
+        }
+
+        [Test]
+        [System.Obsolete]
+        public void TrackCustomPaywallImpressionDeprecatedCtorUsesExplicitOfferingId()
+        {
+            _purchases.TrackCustomPaywallImpression(
+                new Purchases.CustomPaywallImpressionParams("paywall_1", "offering_1"));
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackCustomPaywallImpression), 1);
+            var parameters = (Purchases.CustomPaywallImpressionParams)invocation.Arguments[0];
+            Assert.That(parameters.PaywallId, Is.EqualTo("paywall_1"));
+            Assert.That(parameters.OfferingId, Is.EqualTo("offering_1"));
+            Assert.That(parameters.Offering, Is.Null);
+        }
+
+        [Test]
+        public void TrackAdDisplayedForwardsDataToWrapper()
+        {
+            var data = new AdDisplayedData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "unit_1", "impression_1");
+
+            _purchases.AdTracker.TrackAdDisplayed(data);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackAdDisplayed), 1);
+            Assert.That(invocation.Arguments[0], Is.SameAs(data));
+        }
+
+        [Test]
+        public void TrackAdOpenedForwardsDataToWrapper()
+        {
+            var data = new AdOpenedData(AdTracker.MediatorName.AppLovin, AdTracker.Format.Interstitial, "unit_1", "impression_1");
+
+            _purchases.AdTracker.TrackAdOpened(data);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackAdOpened), 1);
+            Assert.That(invocation.Arguments[0], Is.SameAs(data));
+        }
+
+        [Test]
+        public void TrackAdRevenueForwardsDataToWrapper()
+        {
+            var data = new AdRevenueData(AdTracker.MediatorName.AdMob, AdTracker.Format.Rewarded, "unit_1",
+                "impression_1", 1500000L, "USD", AdTracker.Precision.Exact);
+
+            _purchases.AdTracker.TrackAdRevenue(data);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackAdRevenue), 1);
+            Assert.That(invocation.Arguments[0], Is.SameAs(data));
+        }
+
+        [Test]
+        public void TrackAdLoadedForwardsDataToWrapper()
+        {
+            var data = new AdLoadedData(AdTracker.MediatorName.AdMob, AdTracker.Format.Native, "unit_1", "impression_1");
+
+            _purchases.AdTracker.TrackAdLoaded(data);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackAdLoaded), 1);
+            Assert.That(invocation.Arguments[0], Is.SameAs(data));
+        }
+
+        [Test]
+        public void TrackAdFailedToLoadForwardsDataToWrapper()
+        {
+            var data = new AdFailedToLoadData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "unit_1");
+
+            _purchases.AdTracker.TrackAdFailedToLoad(data);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.TrackAdFailedToLoad), 1);
+            Assert.That(invocation.Arguments[0], Is.SameAs(data));
+        }
+
+        [Test]
+        public void AdDisplayedDataToJsonStringOmitsOptionalFieldsWhenNull()
+        {
+            var data = new AdDisplayedData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "unit_1", "impression_1");
+
+            var json = JSONNode.Parse(data.ToJsonString());
+
+            Assert.That(json["mediatorName"].Value, Is.EqualTo("AdMob"));
+            Assert.That(json["adFormat"].Value, Is.EqualTo("banner"));
+            Assert.That(json["adUnitId"].Value, Is.EqualTo("unit_1"));
+            Assert.That(json["impressionId"].Value, Is.EqualTo("impression_1"));
+            Assert.That(json.HasKey("networkName"), Is.False);
+            Assert.That(json.HasKey("placement"), Is.False);
+        }
+
+        [Test]
+        public void AdDisplayedDataToJsonStringIncludesOptionalFieldsWhenPresent()
+        {
+            var data = new AdDisplayedData(AdTracker.MediatorName.AppLovin, AdTracker.Format.Interstitial, "unit_1",
+                "impression_1", "network_1", "placement_1");
+
+            var json = JSONNode.Parse(data.ToJsonString());
+
+            Assert.That(json["networkName"].Value, Is.EqualTo("network_1"));
+            Assert.That(json["placement"].Value, Is.EqualTo("placement_1"));
+        }
+
+        [Test]
+        public void AdRevenueDataToJsonStringIncludesRevenueFields()
+        {
+            var data = new AdRevenueData(AdTracker.MediatorName.AdMob, AdTracker.Format.Rewarded, "unit_1",
+                "impression_1", 1500000L, "USD", AdTracker.Precision.Exact);
+
+            var json = JSONNode.Parse(data.ToJsonString());
+
+            Assert.That(json["revenueMicros"].AsLong, Is.EqualTo(1500000L));
+            Assert.That(json["currency"].Value, Is.EqualTo("USD"));
+            Assert.That(json["precision"].Value, Is.EqualTo("exact"));
+            Assert.That(json.HasKey("networkName"), Is.False);
+        }
+
+        [Test]
+        public void AdFailedToLoadDataToJsonStringOmitsOptionalFieldsWhenAbsent()
+        {
+            var data = new AdFailedToLoadData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "unit_1");
+
+            var json = JSONNode.Parse(data.ToJsonString());
+
+            Assert.That(json["mediatorName"].Value, Is.EqualTo("AdMob"));
+            Assert.That(json["adFormat"].Value, Is.EqualTo("banner"));
+            Assert.That(json["adUnitId"].Value, Is.EqualTo("unit_1"));
+            Assert.That(json.HasKey("impressionId"), Is.False);
+            Assert.That(json.HasKey("placement"), Is.False);
+            Assert.That(json.HasKey("mediatorErrorCode"), Is.False);
+        }
+
+        [Test]
+        public void AdFailedToLoadDataToJsonStringIncludesOptionalFieldsWhenPresent()
+        {
+            var data = new AdFailedToLoadData(AdTracker.MediatorName.AdMob, AdTracker.Format.Banner, "unit_1",
+                "placement_1", 42);
+
+            var json = JSONNode.Parse(data.ToJsonString());
+
+            Assert.That(json["placement"].Value, Is.EqualTo("placement_1"));
+            Assert.That(json["mediatorErrorCode"].AsInt, Is.EqualTo(42));
+        }
+
+        private PurchasesWrapperSpy.Invocation AssertLastInvocation(string method, int argumentCount)
+        {
+            Assert.That(_wrapper.Invocations, Has.Count.EqualTo(1));
+            Assert.That(_wrapper.LastInvocation.Method, Is.EqualTo(method));
+            Assert.That(_wrapper.LastInvocation.Arguments, Has.Length.EqualTo(argumentCount));
+            return _wrapper.LastInvocation;
+        }
+
+        private static Purchases.Offering CreateOfferingWithPackage()
+        {
+            return new Purchases.Offering(JSONNode.Parse(
+                "{\"identifier\":\"default\",\"serverDescription\":\"desc\",\"availablePackages\":[" +
+                "{\"identifier\":\"$rc_monthly\",\"packageType\":\"MONTHLY\"," +
+                "\"product\":{\"title\":\"Monthly\",\"identifier\":\"monthly\"," +
+                "\"description\":\"Monthly access\",\"price\":9.99,\"priceString\":\"$9.99\"," +
+                "\"currencyCode\":\"USD\",\"productCategory\":\"SUBSCRIPTION\"}," +
+                "\"presentedOfferingContext\":{\"offeringIdentifier\":\"default\"}}" +
+                "]}"
+            ));
+        }
+    }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/TrackingTests.cs.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/TrackingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31362b5f5071458e9ba438e105bbbdee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Part of the #1006 split. Rebased onto `main`; no longer stacked on anything.

Adds `TrackingTests.cs` for custom paywall parameter resolution and ad-tracker forwarding/JSON serialization, and extends `JsonModelTests.cs` with full/minimal `CustomerInfo` and `SubscriptionOption` payloads, the epoch-vs-null date quirk, unrecognized-enum fallbacks, and the `WebPurchaseRedemption`/`WebPurchaseRedemptionResult` variants.

## The JsonModelTests overlap is resolved

The earlier note here warned that this and #1014 both create `JsonModelTests.cs`. #1014 landed first, so I checked what `main` already has before rebasing: `main`'s version holds 4 tests (`VirtualCurrenciesParsesCurrenciesByCode`, `SubscriptionPriceSupportsValuesAboveInt32Range`, `StoreProductParsesKnownProductCategory`, `StoreProductFallsBackToUnknownProductCategory`), this branch's version is a strict superset containing those same 4 with byte-identical bodies plus 11 more. Nothing on `main` is unique, so the rebase keeps this version wholesale — no coverage lost, no duplication introduced. The file now has 15 tests.

## Second commit: fixture fidelity

`MinimalCustomerInfoJson` omitted every field the mappers always send as an explicit null, plus `entitlements.verification`. Android's `convertToJson` maps Kotlin `null` to `JSONObject.NULL` and the iOS mappers use `NSNull()`, so those keys are on the wire, not absent.

The web-redemption error fixture paired `"code":11` with `readableErrorCode: "UNKNOWN_ERROR"` — a value neither platform emits, and inconsistent with the code. Code 11 is `InvalidCredentialsError`, so it now carries the iOS values for that code plus the deprecated `readable_error_code` that ships alongside it.

The synthetic `"UNRECOGNIZED"` and `"BOGUS"` values are unchanged and now carry comments: they stand in for enum members added natively before Unity knows the name, which is exactly what those fallback tests exist to pin down.

Verified against purchases-hybrid-common 18.29.0, which is what `main` pins. The `redeemWebPurchase` result names and per-variant payload shapes (`customerInfo` on success, `error` on failure, `obfuscatedEmail` on expiry, bare `result` for the other two) already matched and were left alone.

## Verification
- [x] Edit Mode tests: 49 passed, 0 failed. Packages rebuilt from this branch and re-imported so the run used this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (fixtures and NUnit tests); no runtime SDK or native bridge behavior is modified.
> 
> **Overview**
> Adds **Edit Mode test coverage** for JSON model parsing and analytics forwarding, without changing production SDK code.
> 
> **JsonModelTests** moves inline JSON into **`JsonModelFixtures`** and adds tests for full **`CustomerInfo`**, full/minimal **`SubscriptionOption`**, millis `0` → null dates, **`UNKNOWN`** fallbacks for unrecognized enums/categories, and all **`WebPurchaseRedemptionResult`** variants (plus **`ArgumentException`** on unknown `result`).
> 
> **TrackingTests** (new) uses **`PurchasesWrapperSpy`** to verify **`TrackCustomPaywallImpression`** parameter resolution (offering id/context from first package, deprecated ctor) and that **`AdTracker`** events forward to the wrapper, including **`ToJsonString`** optional-field omission for ad payload types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd17929bfa8b6c370dede9ac4cae367f1dcfbdf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->