### PR TITLE
Add configuration and harness smoke tests

### DIFF
--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using RevenueCat.SimpleJSON;
+
+namespace RevenueCat.Tests
+{
+    public class JsonModelTests
+    {
+        [Test]
+        public void VirtualCurrenciesParsesCurrenciesByCode()
+        {
+            var response = JSONNode.Parse(
+                "{\"all\":{" +
+                "\"COIN\":{\"balance\":120,\"name\":\"Coins\",\"code\":\"COIN\",\"serverDescription\":\"Earned in game\"}," +
+                "\"GEM\":{\"balance\":4,\"name\":\"Gems\",\"code\":\"GEM\",\"serverDescription\":null}" +
+                "}}"
+            );
+
+            var virtualCurrencies = new Purchases.VirtualCurrencies(response);
+
+            Assert.That(virtualCurrencies.All.Keys, Is.EquivalentTo(new[] { "COIN", "GEM" }));
+            Assert.That(virtualCurrencies.All["COIN"].Balance, Is.EqualTo(120));
+            Assert.That(virtualCurrencies.All["COIN"].Name, Is.EqualTo("Coins"));
+            Assert.That(virtualCurrencies.All["COIN"].ServerDescription, Is.EqualTo("Earned in game"));
+            Assert.That(virtualCurrencies.All["GEM"].Balance, Is.EqualTo(4));
+            Assert.That(virtualCurrencies.All["GEM"].ServerDescription, Is.Null);
+        }
+
+        [Test]
+        public void SubscriptionPriceSupportsValuesAboveInt32Range()
+        {
+            var response = JSONNode.Parse(
+                "{\"formatted\":\"$4,294.97\",\"amountMicros\":4294970000,\"currencyCode\":\"USD\"}"
+            );
+
+            var price = new Purchases.SubscriptionOption.Price(response);
+
+            Assert.That(price.AmountMicros, Is.EqualTo(4294970000L));
+        }
+
+        [Test]
+        public void StoreProductFallsBackToUnknownProductCategory()
+        {
+            var response = JSONNode.Parse(
+                "{\"title\":\"Lifetime\",\"identifier\":\"lifetime\",\"description\":\"Lifetime access\"," +
+                "\"price\":99.99,\"priceString\":\"$99.99\",\"currencyCode\":\"USD\"," +
+                "\"productCategory\":\"UNRECOGNIZED\"}"
+            );
+
+            var product = new Purchases.StoreProduct(response);
+
+            Assert.That(product.Identifier, Is.EqualTo("lifetime"));
+            Assert.That(product.ProductCategory, Is.EqualTo(Purchases.ProductCategory.UNKNOWN));
+            Assert.That(product.DefaultOption, Is.Null);
+            Assert.That(product.Discounts, Is.Null);
+        }
+    }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -38,6 +38,20 @@ namespace RevenueCat.Tests
         }
 
         [Test]
+        public void StoreProductParsesKnownProductCategory()
+        {
+            var response = JSONNode.Parse(
+                "{\"title\":\"Monthly\",\"identifier\":\"monthly\",\"description\":\"Monthly access\"," +
+                "\"price\":9.99,\"priceString\":\"$9.99\",\"currencyCode\":\"USD\"," +
+                "\"productCategory\":\"SUBSCRIPTION\"}"
+            );
+
+            var product = new Purchases.StoreProduct(response);
+
+            Assert.That(product.ProductCategory, Is.EqualTo(Purchases.ProductCategory.SUBSCRIPTION));
+        }
+
+        [Test]
         public void StoreProductFallsBackToUnknownProductCategory()
         {
             var response = JSONNode.Parse(

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90c6103250844a23b9bc88e85907bf37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/PresentedOfferingContextTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PresentedOfferingContextTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using RevenueCat.SimpleJSON;
+
+namespace RevenueCat.Tests
+{
+    public class PresentedOfferingContextTests
+    {
+        [Test]
+        public void JsonRoundTripPreservesAllContext()
+        {
+            var originalJson = JSONNode.Parse(
+                "{\"offeringIdentifier\":\"default\",\"placementIdentifier\":\"onboarding\"," +
+                "\"targetingContext\":{\"revision\":7,\"ruleId\":\"rule-id\"}}"
+            );
+
+            var context = new Purchases.PresentedOfferingContext(originalJson);
+            var serializedContext = JSONNode.Parse(context.ToJsonString());
+
+            Assert.That(serializedContext["offeringIdentifier"].Value, Is.EqualTo("default"));
+            Assert.That(serializedContext["placementIdentifier"].Value, Is.EqualTo("onboarding"));
+            Assert.That(serializedContext["targetingContext"]["revision"].AsInt, Is.EqualTo(7));
+            Assert.That(serializedContext["targetingContext"]["ruleId"].Value, Is.EqualTo("rule-id"));
+        }
+
+        [Test]
+        public void OfferingIdentifierConstructorOmitsOptionalContext()
+        {
+            var context = new Purchases.PresentedOfferingContext("default");
+            var serializedContext = JSONNode.Parse(context.ToJsonString());
+
+            Assert.That(serializedContext["offeringIdentifier"].Value, Is.EqualTo("default"));
+            Assert.That(serializedContext.HasKey("placementIdentifier"), Is.False);
+            Assert.That(serializedContext.HasKey("targetingContext"), Is.False);
+        }
+    }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/PresentedOfferingContextTests.cs.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/PresentedOfferingContextTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a3791f9b503416eafacfbd847ecec71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs
@@ -1,0 +1,74 @@
+using NUnit.Framework;
+using RevenueCat.SimpleJSON;
+using UnityEngine;
+
+namespace RevenueCat.Tests
+{
+    public class PurchasesCallTests
+    {
+        private GameObject _gameObject;
+        private Purchases _purchases;
+        private PurchasesWrapperSpy _wrapper;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gameObject = new GameObject("RevenueCatTests");
+            _purchases = _gameObject.AddComponent<Purchases>();
+            _wrapper = new PurchasesWrapperSpy();
+            _purchases.SetWrapper(_wrapper);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_gameObject);
+        }
+
+        [Test]
+        public void ConfigureForwardsEveryConfigurationValue()
+        {
+            var configuration = Purchases.PurchasesConfiguration.Builder
+                .Init("test_api_key")
+                .SetAppUserId("app_user_id")
+                .SetPurchasesAreCompletedBy(Purchases.PurchasesAreCompletedBy.MyApp,
+                    Purchases.StoreKitVersion.StoreKit2)
+                .SetUserDefaultsSuiteName("suite_name")
+                .SetUseAmazon(true)
+                .SetDangerousSettings(new Purchases.DangerousSettings(false))
+                .SetShouldShowInAppMessagesAutomatically(true)
+                .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
+                .SetPendingTransactionsForPrepaidPlansEnabled(true)
+                .SetDiagnosticsEnabled(true)
+                .SetAutomaticDeviceIdentifierCollectionEnabled(false)
+                .SetPreferredUILocaleOverride("de_DE")
+                .Build();
+
+            _purchases.Configure(configuration);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.Setup), 14);
+            Assert.That(invocation.Arguments[0], Is.EqualTo(_gameObject.name));
+            Assert.That(invocation.Arguments[1], Is.EqualTo("test_api_key"));
+            Assert.That(invocation.Arguments[2], Is.EqualTo("app_user_id"));
+            Assert.That(invocation.Arguments[3], Is.EqualTo(Purchases.PurchasesAreCompletedBy.MyApp));
+            Assert.That(invocation.Arguments[4], Is.EqualTo(Purchases.StoreKitVersion.StoreKit2));
+            Assert.That(invocation.Arguments[5], Is.EqualTo("suite_name"));
+            Assert.That(invocation.Arguments[6], Is.True);
+            Assert.That(JSONNode.Parse((string)invocation.Arguments[7])["AutoSyncPurchases"].AsBool, Is.False);
+            Assert.That(invocation.Arguments[8], Is.True);
+            Assert.That(invocation.Arguments[9], Is.EqualTo(Purchases.EntitlementVerificationMode.Informational));
+            Assert.That(invocation.Arguments[10], Is.True);
+            Assert.That(invocation.Arguments[11], Is.True);
+            Assert.That(invocation.Arguments[12], Is.False);
+            Assert.That(invocation.Arguments[13], Is.EqualTo("de_DE"));
+        }
+
+        private PurchasesWrapperSpy.Invocation AssertLastInvocation(string method, int argumentCount)
+        {
+            Assert.That(_wrapper.Invocations, Has.Count.EqualTo(1));
+            Assert.That(_wrapper.LastInvocation.Method, Is.EqualTo(method));
+            Assert.That(_wrapper.LastInvocation.Arguments, Has.Length.EqualTo(argumentCount));
+            return _wrapper.LastInvocation;
+        }
+    }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs
@@ -35,7 +35,7 @@ namespace RevenueCat.Tests
                     Purchases.StoreKitVersion.StoreKit2)
                 .SetUserDefaultsSuiteName("suite_name")
                 .SetUseAmazon(true)
-                .SetDangerousSettings(new Purchases.DangerousSettings(false))
+                .SetDangerousSettings(new Purchases.DangerousSettings(false, true))
                 .SetShouldShowInAppMessagesAutomatically(true)
                 .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
                 .SetPendingTransactionsForPrepaidPlansEnabled(true)
@@ -46,7 +46,7 @@ namespace RevenueCat.Tests
 
             _purchases.Configure(configuration);
 
-            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.Setup), 14);
+            var invocation = AssertOnlyInvocation(nameof(IPurchasesWrapper.Setup), 14);
             Assert.That(invocation.Arguments[0], Is.EqualTo(_gameObject.name));
             Assert.That(invocation.Arguments[1], Is.EqualTo("test_api_key"));
             Assert.That(invocation.Arguments[2], Is.EqualTo("app_user_id"));
@@ -54,7 +54,9 @@ namespace RevenueCat.Tests
             Assert.That(invocation.Arguments[4], Is.EqualTo(Purchases.StoreKitVersion.StoreKit2));
             Assert.That(invocation.Arguments[5], Is.EqualTo("suite_name"));
             Assert.That(invocation.Arguments[6], Is.True);
-            Assert.That(JSONNode.Parse((string)invocation.Arguments[7])["AutoSyncPurchases"].AsBool, Is.False);
+            var dangerousSettings = JSONNode.Parse((string)invocation.Arguments[7]);
+            Assert.That(dangerousSettings["AutoSyncPurchases"].AsBool, Is.False);
+            Assert.That(dangerousSettings["UseWorkflows"].AsBool, Is.True);
             Assert.That(invocation.Arguments[8], Is.True);
             Assert.That(invocation.Arguments[9], Is.EqualTo(Purchases.EntitlementVerificationMode.Informational));
             Assert.That(invocation.Arguments[10], Is.True);
@@ -63,12 +65,14 @@ namespace RevenueCat.Tests
             Assert.That(invocation.Arguments[13], Is.EqualTo("de_DE"));
         }
 
-        private PurchasesWrapperSpy.Invocation AssertLastInvocation(string method, int argumentCount)
+        private PurchasesWrapperSpy.Invocation AssertOnlyInvocation(string method, int argumentCount)
         {
             Assert.That(_wrapper.Invocations, Has.Count.EqualTo(1));
-            Assert.That(_wrapper.LastInvocation.Method, Is.EqualTo(method));
-            Assert.That(_wrapper.LastInvocation.Arguments, Has.Length.EqualTo(argumentCount));
-            return _wrapper.LastInvocation;
+
+            var invocation = _wrapper.Invocations[0];
+            Assert.That(invocation.Method, Is.EqualTo(method));
+            Assert.That(invocation.Arguments, Has.Length.EqualTo(argumentCount));
+            return invocation;
         }
     }
 }

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30b46e0ec5314d2b9e881bb88b801d64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs
@@ -1,0 +1,75 @@
+using NUnit.Framework;
+
+namespace RevenueCat.Tests
+{
+    public class PurchasesConfigurationTests
+    {
+        [Test]
+        public void BuildUsesDocumentedDefaults()
+        {
+            var configuration = Purchases.PurchasesConfiguration.Builder
+                .Init("test_api_key")
+                .Build();
+
+            Assert.That(configuration.ApiKey, Is.EqualTo("test_api_key"));
+            Assert.That(configuration.AppUserId, Is.Null);
+            Assert.That(configuration.PurchasesAreCompletedBy, Is.EqualTo(default(Purchases.PurchasesAreCompletedBy)));
+            Assert.That(configuration.UserDefaultsSuiteName, Is.Null);
+            Assert.That(configuration.UseAmazon, Is.False);
+            Assert.That(configuration.DangerousSettings.AutoSyncPurchases, Is.True);
+            Assert.That(configuration.StoreKitVersion, Is.EqualTo(default(Purchases.StoreKitVersion)));
+            Assert.That(configuration.ShouldShowInAppMessagesAutomatically, Is.False);
+            Assert.That(configuration.EntitlementVerificationMode, Is.EqualTo(default(Purchases.EntitlementVerificationMode)));
+            Assert.That(configuration.PendingTransactionsForPrepaidPlansEnabled, Is.False);
+            Assert.That(configuration.DiagnosticsEnabled, Is.False);
+            Assert.That(configuration.AutomaticDeviceIdentifierCollectionEnabled, Is.True);
+            Assert.That(configuration.PreferredUILocaleOverride, Is.Null);
+        }
+
+        [Test]
+        public void BuildUsesConfiguredValues()
+        {
+            var dangerousSettings = new Purchases.DangerousSettings(false);
+
+            var configuration = Purchases.PurchasesConfiguration.Builder
+                .Init("test_api_key")
+                .SetAppUserId("app_user_id")
+                .SetPurchasesAreCompletedBy(Purchases.PurchasesAreCompletedBy.MyApp, Purchases.StoreKitVersion.StoreKit2)
+                .SetUserDefaultsSuiteName("suite_name")
+                .SetUseAmazon(true)
+                .SetDangerousSettings(dangerousSettings)
+                .SetShouldShowInAppMessagesAutomatically(true)
+                .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
+                .SetPendingTransactionsForPrepaidPlansEnabled(true)
+                .SetDiagnosticsEnabled(true)
+                .SetAutomaticDeviceIdentifierCollectionEnabled(false)
+                .SetPreferredUILocaleOverride("de_DE")
+                .Build();
+
+            Assert.That(configuration.AppUserId, Is.EqualTo("app_user_id"));
+            Assert.That(configuration.PurchasesAreCompletedBy, Is.EqualTo(Purchases.PurchasesAreCompletedBy.MyApp));
+            Assert.That(configuration.StoreKitVersion, Is.EqualTo(Purchases.StoreKitVersion.StoreKit2));
+            Assert.That(configuration.UserDefaultsSuiteName, Is.EqualTo("suite_name"));
+            Assert.That(configuration.UseAmazon, Is.True);
+            Assert.That(configuration.DangerousSettings, Is.SameAs(dangerousSettings));
+            Assert.That(configuration.ShouldShowInAppMessagesAutomatically, Is.True);
+            Assert.That(configuration.EntitlementVerificationMode, Is.EqualTo(Purchases.EntitlementVerificationMode.Informational));
+            Assert.That(configuration.PendingTransactionsForPrepaidPlansEnabled, Is.True);
+            Assert.That(configuration.DiagnosticsEnabled, Is.True);
+            Assert.That(configuration.AutomaticDeviceIdentifierCollectionEnabled, Is.False);
+            Assert.That(configuration.PreferredUILocaleOverride, Is.EqualTo("de_DE"));
+        }
+
+        [Test]
+        public void BuildRestoresDefaultDangerousSettingsWhenSetToNull()
+        {
+            var configuration = Purchases.PurchasesConfiguration.Builder
+                .Init("test_api_key")
+                .SetDangerousSettings(null)
+                .Build();
+
+            Assert.That(configuration.DangerousSettings, Is.Not.Null);
+            Assert.That(configuration.DangerousSettings.AutoSyncPurchases, Is.True);
+        }
+    }
+}

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs
@@ -4,8 +4,17 @@ namespace RevenueCat.Tests
 {
     public class PurchasesConfigurationTests
     {
+        /// <remarks>
+        /// This locks in what the builder does today, which is not what the SDK documents.
+        /// The builder leaves StoreKitVersion, ShouldShowInAppMessagesAutomatically and
+        /// EntitlementVerificationMode at their C# zero values, so the runtime-setup path defaults to
+        /// StoreKit 1, in-app messages disabled and verification disabled, while the inspector fields on
+        /// Purchases default to StoreKitVersion.Default, in-app messages enabled and Informational.
+        /// Those divergences look unintentional, but aligning the builder changes runtime behavior for
+        /// apps using runtime setup, so it is handled separately from these tests.
+        /// </remarks>
         [Test]
-        public void BuildUsesDocumentedDefaults()
+        public void BuildUsesBuilderDefaults()
         {
             var configuration = Purchases.PurchasesConfiguration.Builder
                 .Init("test_api_key")
@@ -13,13 +22,16 @@ namespace RevenueCat.Tests
 
             Assert.That(configuration.ApiKey, Is.EqualTo("test_api_key"));
             Assert.That(configuration.AppUserId, Is.Null);
-            Assert.That(configuration.PurchasesAreCompletedBy, Is.EqualTo(default(Purchases.PurchasesAreCompletedBy)));
+            Assert.That(configuration.PurchasesAreCompletedBy, Is.EqualTo(Purchases.PurchasesAreCompletedBy.RevenueCat));
             Assert.That(configuration.UserDefaultsSuiteName, Is.Null);
             Assert.That(configuration.UseAmazon, Is.False);
             Assert.That(configuration.DangerousSettings.AutoSyncPurchases, Is.True);
-            Assert.That(configuration.StoreKitVersion, Is.EqualTo(default(Purchases.StoreKitVersion)));
+            // Diverges from the Purchases inspector default (StoreKitVersion.Default).
+            Assert.That(configuration.StoreKitVersion, Is.EqualTo(Purchases.StoreKitVersion.StoreKit1));
+            // Diverges from the documented default (in-app messages are shown automatically).
             Assert.That(configuration.ShouldShowInAppMessagesAutomatically, Is.False);
-            Assert.That(configuration.EntitlementVerificationMode, Is.EqualTo(default(Purchases.EntitlementVerificationMode)));
+            // Diverges from the Purchases inspector default (EntitlementVerificationMode.Informational).
+            Assert.That(configuration.EntitlementVerificationMode, Is.EqualTo(Purchases.EntitlementVerificationMode.Disabled));
             Assert.That(configuration.PendingTransactionsForPrepaidPlansEnabled, Is.False);
             Assert.That(configuration.DiagnosticsEnabled, Is.False);
             Assert.That(configuration.AutomaticDeviceIdentifierCollectionEnabled, Is.True);

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6566b7a4beb347cda9e2e33f4924819f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Part of the #1006 split, stacked on #1009.

Adds baseline tests exercising the harness end to end: `Configure` forwarding through the wrapper spy, configuration builder defaults, presented-offering-context resolution, and baseline JSON model parsing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime SDK changes; low risk aside from documenting intentional configuration-builder default mismatches.
> 
> **Overview**
> Adds **EditMode NUnit tests** under `IntegrationTests/Assets/Tests/EditMode/` as part of the #1006 split (stacked on #1009). No production SDK code changes—only new test coverage and Unity `.meta` files.
> 
> **Harness / configure:** `PurchasesCallTests` wires `Purchases` to `PurchasesWrapperSpy` and asserts `Configure` forwards a fully populated `PurchasesConfiguration` to `IPurchasesWrapper.Setup` with all 14 arguments (including dangerous settings JSON).
> 
> **Configuration builder:** `PurchasesConfigurationTests` documents and locks in builder defaults vs inspector/docs (StoreKit 1, in-app messages off, verification disabled), custom builder values, and null `DangerousSettings` restoring defaults.
> 
> **Models:** `PresentedOfferingContextTests` covers JSON round-trip and minimal constructor serialization. `JsonModelTests` covers virtual currencies, subscription price micros above `int32`, store product category parsing, and unknown category fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a1b01810efd2b75908d79d5d6dc515010ec821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->