### PR TITLE
Add onWebCheckoutOpened and onUrlOpened callbacks to PaywallListener

### DIFF
--- a/IntegrationTests/Assets/APITests/PaywallListenerAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PaywallListenerAPITests.cs
@@ -23,7 +23,9 @@ namespace DefaultNamespace
                 OnPurchaseCancelled = () => { },
                 OnRestoreStarted = () => { },
                 OnRestoreCompleted = customerInfo => { Purchases.CustomerInfo info = customerInfo; },
-                OnRestoreError = error => { Purchases.Error e = error; }
+                OnRestoreError = error => { Purchases.Error e = error; },
+                OnWebCheckoutOpened = () => { },
+                OnUrlOpened = url => { string u = url; }
             };
 
             // Test property setters and getters
@@ -35,6 +37,8 @@ namespace DefaultNamespace
             System.Action onRestoreStarted = listener.OnRestoreStarted;
             System.Action<Purchases.CustomerInfo> onRestoreCompleted = listener.OnRestoreCompleted;
             System.Action<Purchases.Error> onRestoreError = listener.OnRestoreError;
+            System.Action onWebCheckoutOpened = listener.OnWebCheckoutOpened;
+            System.Action<string> onUrlOpened = listener.OnUrlOpened;
 
             // Test PaywallOptions with listener
             PaywallOptions options1 = new PaywallOptions(listener: listener);

--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/src/main/java/com/revenuecat/purchasesunity/ui/PaywallViewPresenter.java
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/src/main/java/com/revenuecat/purchasesunity/ui/PaywallViewPresenter.java
@@ -449,10 +449,30 @@ public class PaywallViewPresenter {
 
             @Override
             public void onWebCheckoutOpened() {
+                // No FLAG_NOT_FOCUSABLE here, unlike onPurchaseStarted: there is no later
+                // native signal for when the web checkout closes, so C# would have to
+                // acknowledge this same event as terminal, releasing the flag on its own
+                // round trip (roughly one frame) rather than when the browser Activity
+                // actually backgrounds Unity (typically 100ms+ later). That window is too
+                // short to protect anything and would clear the flag before it matters.
+                if (forwardEvents) {
+                    RevenueCatUI.sendPaywallEvent("onWebCheckoutOpened", null);
+                }
             }
 
             @Override
             public void onUrlOpened(@NonNull String url) {
+                // No FLAG_NOT_FOCUSABLE here: opening a URL is not a purchase/restore flow with
+                // a terminal acknowledgement, same as onWebCheckoutOpened above.
+                if (forwardEvents) {
+                    try {
+                        JSONObject payload = new JSONObject();
+                        payload.put("url", url);
+                        RevenueCatUI.sendPaywallEvent("onUrlOpened", payload.toString());
+                    } catch (Throwable e) {
+                        Log.w(TAG, "Failed to send onUrlOpened event: " + e.getMessage());
+                    }
+                }
             }
         };
     }

--- a/RevenueCatUI/Plugins/iOS/RevenueCatUI.m
+++ b/RevenueCatUI/Plugins/iOS/RevenueCatUI.m
@@ -212,6 +212,15 @@ didFailPurchasingWithErrorDictionary:(NSDictionary<NSString *, id> *)errorDictio
     RCUIEmitPaywallEvent(self.eventCallback, "onRestoreStarted", nil);
 }
 
+- (void)paywallViewControllerDidOpenWebCheckout:(RCPaywallViewController *)controller API_AVAILABLE(ios(15.0)) {
+    RCUIEmitPaywallEvent(self.eventCallback, "onWebCheckoutOpened", nil);
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+                   didOpenURL:(NSString *)url API_AVAILABLE(ios(15.0)) {
+    RCUIEmitPaywallEvent(self.eventCallback, "onUrlOpened", @{@"url": url ?: @""});
+}
+
 - (void)paywallViewController:(RCPaywallViewController *)controller
 didFinishRestoringWithCustomerInfoDictionary:(NSDictionary<NSString *, id> *)customerInfoDictionary API_AVAILABLE(ios(15.0)) {
     RCUIEmitPaywallEvent(self.eventCallback, "onRestoreCompleted", @{@"customerInfo": customerInfoDictionary ?: @{}});

--- a/RevenueCatUI/Scripts/Internal/PaywallListenerBridge.cs
+++ b/RevenueCatUI/Scripts/Internal/PaywallListenerBridge.cs
@@ -23,6 +23,8 @@ namespace RevenueCatUI.Internal
         private const string EventRestoreStarted = "onRestoreStarted";
         private const string EventRestoreCompleted = "onRestoreCompleted";
         private const string EventRestoreError = "onRestoreError";
+        private const string EventWebCheckoutOpened = "onWebCheckoutOpened";
+        private const string EventUrlOpened = "onUrlOpened";
 
         private static PaywallListener s_currentListener;
         private static SynchronizationContext s_mainThreadContext;
@@ -136,6 +138,12 @@ namespace RevenueCatUI.Internal
                     case EventRestoreError:
                         listener.OnRestoreError?.Invoke(new Purchases.Error(payload["error"]));
                         break;
+                    case EventWebCheckoutOpened:
+                        listener.OnWebCheckoutOpened?.Invoke();
+                        break;
+                    case EventUrlOpened:
+                        listener.OnUrlOpened?.Invoke(payload["url"].Value);
+                        break;
                     default:
                         Debug.LogWarning($"[RevenueCatUI] Unknown paywall event '{eventName}'; ignoring.");
                         break;
@@ -149,6 +157,9 @@ namespace RevenueCatUI.Internal
 
         private static bool IsTerminalEvent(string eventName)
         {
+            // OnWebCheckoutOpened is not included here: it does not set the not-focusable
+            // flag on Android (see PaywallViewPresenter.onWebCheckoutOpened), so there is
+            // no flag op to release for it.
             return eventName == EventPurchaseCompleted
                 || eventName == EventPurchaseError
                 || eventName == EventPurchaseCancelled

--- a/RevenueCatUI/Scripts/PaywallListener.cs
+++ b/RevenueCatUI/Scripts/PaywallListener.cs
@@ -52,5 +52,17 @@ namespace RevenueCatUI
         /// Invoked when a restore fails.
         /// </summary>
         public Action<Purchases.Error> OnRestoreError { get; set; }
+
+        /// <summary>
+        /// Invoked when the user taps a web checkout CTA and leaves the app to complete
+        /// payment externally.
+        /// </summary>
+        public Action OnWebCheckoutOpened { get; set; }
+
+        /// <summary>
+        /// Invoked when the paywall successfully opens a URL, either from a button with a URL
+        /// destination or from a link inside a text component. Not called for web checkout URLs.
+        /// </summary>
+        public Action<string> OnUrlOpened { get; set; }
     }
 }

--- a/Subtester/Assets/Tester/Scripts/Screens/PaywallScreen.cs
+++ b/Subtester/Assets/Tester/Scripts/Screens/PaywallScreen.cs
@@ -65,7 +65,11 @@ namespace RevenueCat.Tester.Screens
                 OnRestoreCompleted = customerInfo =>
                     LogSuccess($"Listener: restore completed — active entitlements: {customerInfo?.Entitlements?.Active?.Count}"),
                 OnRestoreError = error =>
-                    LogError($"Listener: restore error — {error?.Message}")
+                    LogError($"Listener: restore error — {error?.Message}"),
+                OnWebCheckoutOpened = () =>
+                    Log("Listener: web checkout opened"),
+                OnUrlOpened = url =>
+                    Log($"Listener: url opened: {url}")
             };
         }
 


### PR DESCRIPTION
Exposes RevenueCat/purchases-hybrid-common#1776

Adds `OnWebCheckoutOpened` and `OnUrlOpened` to Unity's `PaywallListener`.

## Usage

```csharp
var result = await PaywallsPresenter.Present(new PaywallOptions(
    offering,
    listener: new PaywallListener
    {
        // ...existing callbacks...
        OnWebCheckoutOpened = () => { /* user left to complete web checkout externally */ },
        OnUrlOpened = url => { /* paywall opened a URL: a button URL destination or a text link */ },
    }));
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds paywall lifecycle plumbing and Android dialog focus behavior documentation; changes are additive but affect timing of Unity player loop and listener delivery during checkout/URL flows.
> 
> **Overview**
> Extends **`PaywallListener`** with **`OnWebCheckoutOpened`** (external web checkout) and **`OnUrlOpened`** (non-checkout URLs from buttons or text links), wired through **`PaywallListenerBridge`** on the same native `(eventName, payloadJson)` channel as existing purchase/restore events.
> 
> **Android** forwards both events from `PaywallViewPresenter` when listener forwarding is enabled; **`onWebCheckoutOpened`** and **`onUrlOpened`** deliberately do **not** toggle **`FLAG_NOT_FOCUSABLE`** or count as terminal acknowledgements, with inline rationale (no native “checkout closed” signal; treating them as terminal would clear the flag too early).
> 
> **iOS** emits matching events from **`RCUIPaywallDelegate`** (`paywallViewControllerDidOpenWebCheckout`, `didOpenURL`).
> 
> API integration tests and Subtester logging cover the new callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9f85534fa4a18ac0511956ca8970c0819ae1530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
