### PR TITLE
fix: surface native errors from GetCurrentOfferingForPlacement

### DIFF
--- a/IntegrationTests/Assets/Tests/EditMode/CallbackResponseTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/CallbackResponseTests.cs
@@ -617,7 +617,7 @@ namespace RevenueCat.Tests
         }
 
         [Test]
-        public void GetCurrentOfferingForPlacementDropsNativeError()
+        public void GetCurrentOfferingForPlacementDeliversNativeError()
         {
             Purchases.Offering receivedOffering = CreateOffering();
             Purchases.Error receivedError = null;
@@ -630,16 +630,16 @@ namespace RevenueCat.Tests
                 receivedError = error;
             });
 
-            // Both wrappers send only the "error" key on failure — no "offering" key. The
-            // receiver's missing-offering guard runs before its error check, so the error is
-            // dropped and the caller cannot tell a failure from "no offering for placement".
-            // This documents current behaviour, not desired behaviour.
+            // Both wrappers send only the "error" key on failure — no "offering" key — so a
+            // failure has to be distinguishable from "no offering configured for this placement".
             SendNativeResponse("_getCurrentOfferingForPlacement",
                 ErrorJson(10, "A network error has occurred.", "NETWORK_ERROR"));
 
             Assert.That(callbackCount, Is.EqualTo(1));
             Assert.That(receivedOffering, Is.Null);
-            Assert.That(receivedError, Is.Null);
+            Assert.That(receivedError, Is.Not.Null);
+            Assert.That(receivedError.Code, Is.EqualTo(10));
+            Assert.That(receivedError.ReadableErrorCode, Is.EqualTo("NETWORK_ERROR"));
         }
 
         [Test]

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -1669,20 +1669,20 @@ public partial class Purchases : MonoBehaviour
         var response = JSON.Parse(offeringJson);
         var callback = GetCurrentOfferingForPlacementCallback;
         GetCurrentOfferingForPlacementCallback = null;
+        // The error check has to come first: both native wrappers send only an "error" key on
+        // failure, so testing for a missing "offering" first reports every failure as
+        // "no offering configured for this placement".
+        if (ResponseHasError(response))
+        {
+            callback(null, new Error(response["error"]));
+            return;
+        }
         if (response == null || response["offering"] == null)
         {
             callback(null, null);
             return;
         }
-        if (ResponseHasError(response))
-        {
-            callback(null, new Error(response["error"]));
-        }
-        else
-        {
-            var offeringResponse = response["offering"];
-            callback(new Offering(offeringResponse), null);
-        }
+        callback(new Offering(response["offering"]), null);
     }
 
     // ReSharper disable once UnusedMember.Local


### PR DESCRIPTION
## What changed

`GetCurrentOfferingForPlacement` could never report a failure. Both native wrappers send only an `error` key when the offerings fetch fails — there is no `offering` key in that payload — but `_getCurrentOfferingForPlacement` tested for a missing `offering` first and returned early with `callback(null, null)`. The error was dropped, so a network failure looked exactly like "no offering is configured for this placement".

Moving the error check ahead of the missing-offering guard fixes it.

## Base branch

Stacked on `cesar/unity-callback-response-tests` (#1012), which adds the test file this builds on.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes callback semantics for placement offerings on the Unity bridge; apps that relied on `(null, null)` for failures may need to handle `Error`, but the fix aligns behavior with other offerings APIs and is covered by tests.
> 
> **Overview**
> **`GetCurrentOfferingForPlacement`** now forwards native failures to the app callback instead of treating them like an empty placement.
> 
> In **`_getCurrentOfferingForPlacement`**, **`ResponseHasError`** runs **before** the missing-`offering` guard. On failure, iOS/Android only send an **`error`** key (no **`offering`**), so the old order always invoked **`callback(null, null)`** and hid network and other errors.
> 
> The edit-mode test **`GetCurrentOfferingForPlacementDeliversNativeError`** now expects a populated **`Error`** (e.g. code 10, **`NETWORK_ERROR`**) instead of documenting dropped errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72bdc79fd70cc7bab5140c4059eeafaf825c467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->