### PR TITLE
fix(ios): send one _makePurchase message per purchase attempt

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -160,10 +160,9 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response = [NSMutableDictionary new];
             response[@"error"] = error.info;
             response[@"userCancelled"] = error.info[@"userCancelled"];
-            [self sendJSONObject:response toMethod:MAKE_PURCHASE];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
-            response[@"userCancelled"] = false;
+            response[@"userCancelled"] = @NO;
         }
         [self sendJSONObject:response toMethod:MAKE_PURCHASE];
     }];
@@ -181,7 +180,6 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response = [NSMutableDictionary new];
             response[@"error"] = error.info;
             response[@"userCancelled"] = error.info[@"userCancelled"];
-            [self sendJSONObject:response toMethod:MAKE_PURCHASE];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
             response[@"userCancelled"] = @NO;
@@ -558,7 +556,7 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response[@"userCancelled"] = error.info[@"userCancelled"];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
-            response[@"userCancelled"] = false;
+            response[@"userCancelled"] = @NO;
         }
         [self sendJSONObject:response toMethod:PURCHASE_PRODUCT_WITH_WIN_BACK_OFFER];
     }];
@@ -593,7 +591,7 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response[@"userCancelled"] = error.info[@"userCancelled"];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
-            response[@"userCancelled"] = false;
+            response[@"userCancelled"] = @NO;
         }
         [self sendJSONObject:response toMethod:PURCHASE_PACKAGE_WITH_WIN_BACK_OFFER];
     }];


### PR DESCRIPTION
## What changed

`purchaseProduct` and `purchasePackage` sent the response to `_makePurchase` twice on failure — once inside the error branch, and again from the unconditional send after the `if/else`:

```objc
if (error) {
    ...
    [self sendJSONObject:response toMethod:MAKE_PURCHASE];   // first
} else {
    ...
}
[self sendJSONObject:response toMethod:MAKE_PURCHASE];       // second, always runs
```

Only the first delivery reaches the caller today, because `_makePurchase` clears `MakePurchaseCallback` before invoking it, so the duplicate is dropped by the null guard. The extra `UnitySendMessage` is still wasted work on the wrong contract. The two win-back offer handlers already had the correct single-send shape; this makes all four consistent.

## Also in this PR

`response[@"userCancelled"] = false` appeared in three places. `false` is `0`, so it boxes to `nil`, and assigning `nil` through an `NSMutableDictionary` subscript *removes* the key rather than storing it — the success payload shipped with no `userCancelled` field at all. Unity reads the missing key as `false` via SimpleJSON, so the behaviour was correct by accident. Replaced with `@NO` so the payload matches what `PurchaseResult` expects. `purchasePackage` already used `@NO`, which is what made the inconsistency visible.

## Overlaps with #1008

#1008 rewrites these same lines for request-ID correlation and carries the double send unchanged. It will conflict with this PR, and the duplicate matters more there: once callbacks are consumed by request ID, the second message arrives as an unrecognised request rather than being dropped by a null check.

## Verification

- [x] Compiles: `archive-ios`, `archive-ios-cocoapods`, `build-integration-tests-ios` and `build-subtester-ios` all pass on CI, so the plugin builds and links.
- [ ] Runtime behaviour of a failed purchase — not covered.

No test in this repo exercises `PurchasesUnityHelper.m` at runtime, and Edit Mode tests do not compile the iOS plugin, so the single-send behaviour on a failed purchase is unverified. Worth a manual check in Subtester (cancel a purchase, confirm one `_makePurchase` log line) before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)