### PR TITLE
Don't run `deploy-check` on `bump` and `phc-upgrade` pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,16 +516,20 @@ workflows:
   version: 2
   danger:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
       - revenuecat/danger:
           ruby_version: "3.3.0"
 
   deploy-check:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
       - check-meta-files
       - check-android-keep-annotations
@@ -582,10 +586,12 @@ workflows:
 
   deploy:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
-      - export-package: 
+      - export-package:
           context: unity
           <<: *release-tags
       - github-release:


### PR DESCRIPTION
`danger`, `deploy-check` and `deploy` were gated only on "not a scheduled pipeline". So API-triggered pipelines (like `action: bump`, `action: upgrade-hybrid-common`) pass that check, so every bump was also running the whole `deploy-check` matrix.

That work was redundant on top of being wasted. `automatic-bump` pushes a `release/x.y.z` branch, and that push triggers its own pipeline with `action` at its `build` default, which runs `deploy-check` properly. So `deploy-check` ran twice per bump.

Gated all three workflows on `action == build`, the same way purchases-android gates its workflows on `action == default`. Tag pushes and normal branch pushes get `action: build` by default, so nothing changes for them.

**Before**
<img width="2035" height="781" alt="Captura de pantalla 2026-07-31 a las 10 02 09" src="https://github.com/user-attachments/assets/691c7858-e847-4c31-be24-409ec896c071" />
**After**
<img width="2025" height="200" alt="Captura de pantalla 2026-07-31 a las 10 02 28" src="https://github.com/user-attachments/assets/ac19d8bd-cfe1-4269-a3a7-4cf0737e9ed1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow gating only; no application code, auth, or release artifact logic changes.
> 
> **Overview**
> **danger**, **deploy-check**, and **deploy** now run only when `pipeline.parameters.action` is `build`, in addition to the existing “not a scheduled pipeline” rule.
> 
> API-triggered pipelines (`bump`, `upgrade-hybrid-common`) no longer run Danger or the full deploy-check matrix on the same run as the bump/PHC job. Release branches still get **deploy-check** from the follow-up pipeline triggered when `automatic-bump` pushes `release/*` with the default `action: build`.
> 
> Tag and normal branch pushes are unchanged because `action` defaults to `build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d437537ea776a416abc8114db5d37cf6b02063f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->