### PR TITLE
Revert "[AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.28.0"

### DIFF
--- a/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
+++ b/RevenueCat/Plugins/Editor/RevenueCatDependencies.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[18.28.0]" />
+        <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common:[18.27.0]" />
         <androidPackage spec="androidx.annotation:annotation:[1.2.0]" />
     </androidPackages>
-    <remoteSwiftPackage url="https://github.com/RevenueCat/purchases-hybrid-common.git" version="18.28.0">
+    <remoteSwiftPackage url="https://github.com/RevenueCat/purchases-hybrid-common.git" version="18.27.0">
         <swiftPackage name="PurchasesHybridCommon" replacesPod="PurchasesHybridCommon" />
     </remoteSwiftPackage>
     <iosPods>
-        <iosPod name="PurchasesHybridCommon" version="18.28.0" minTargetSdk="13.0"/>
+        <iosPod name="PurchasesHybridCommon" version="18.27.0" minTargetSdk="13.0"/>
     </iosPods>
 </dependencies>

--- a/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
+++ b/RevenueCatUI/Plugins/Android/RevenueCatUI.androidlib/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.library'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:18.28.0'
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common-ui:18.28.0'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:18.27.0'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common-ui:18.27.0'
     implementation 'androidx.activity:activity:1.8.2'
     // Required at compile time so the Java compiler can resolve PaywallView's
     // class hierarchy (PaywallView -> CompatComposeView -> AbstractComposeView -> ViewGroup).

--- a/RevenueCatUI/Plugins/Editor/RevenueCatUIDependencies.xml
+++ b/RevenueCatUI/Plugins/Editor/RevenueCatUIDependencies.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common-ui:[18.28.0]" />
+    <androidPackage spec="com.revenuecat.purchases:purchases-hybrid-common-ui:[18.27.0]" />
     <androidPackage spec="androidx.activity:activity:1.8.2" />
   </androidPackages>
 
-  <remoteSwiftPackage url="https://github.com/RevenueCat/purchases-hybrid-common.git" version="18.28.0">
+  <remoteSwiftPackage url="https://github.com/RevenueCat/purchases-hybrid-common.git" version="18.27.0">
     <swiftPackage name="PurchasesHybridCommonUI" replacesPod="PurchasesHybridCommonUI" />
   </remoteSwiftPackage>
 
   <iosPods>
-    <iosPod name="PurchasesHybridCommonUI" version="~> 18.28.0" />
+    <iosPod name="PurchasesHybridCommonUI" version="~> 18.27.0" />
   </iosPods>
 </dependencies> 

--- a/Subtester/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Subtester/Assets/Plugins/Android/mainTemplate.gradle
@@ -8,8 +8,8 @@ dependencies {
 // Android Resolver Dependencies Start
     implementation 'androidx.activity:activity:1.8.2' // Packages/com.revenuecat.purchases-ui-unity/Plugins/Editor/RevenueCatUIDependencies.xml:6
     implementation 'androidx.annotation:annotation:[1.2.0]' // Packages/com.revenuecat.purchases-unity/Plugins/Editor/RevenueCatDependencies.xml:5
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:[18.28.0]' // Packages/com.revenuecat.purchases-unity/Plugins/Editor/RevenueCatDependencies.xml:4
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common-ui:[18.28.0]' // Packages/com.revenuecat.purchases-ui-unity/Plugins/Editor/RevenueCatUIDependencies.xml:5
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:[18.27.0]' // Packages/com.revenuecat.purchases-unity/Plugins/Editor/RevenueCatDependencies.xml:4
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common-ui:[18.27.0]' // Packages/com.revenuecat.purchases-ui-unity/Plugins/Editor/RevenueCatUIDependencies.xml:5
 // Android Resolver Dependencies End
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.14'
 **DEPS**}

--- a/Subtester/ProjectSettings/AndroidResolverDependencies.xml
+++ b/Subtester/ProjectSettings/AndroidResolverDependencies.xml
@@ -2,8 +2,8 @@
   <packages>
     <package>androidx.activity:activity:1.8.2</package>
     <package>androidx.annotation:annotation:[1.2.0]</package>
-    <package>com.revenuecat.purchases:purchases-hybrid-common:[18.28.0]</package>
-    <package>com.revenuecat.purchases:purchases-hybrid-common-ui:[18.28.0]</package>
+    <package>com.revenuecat.purchases:purchases-hybrid-common:[18.27.0]</package>
+    <package>com.revenuecat.purchases:purchases-hybrid-common-ui:[18.27.0]</package>
   </packages>
   <files />
   <settings>


### PR DESCRIPTION
Reverts RevenueCat/purchases-unity#1029

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version rollback only; no application logic changes, though builds will ship the older hybrid-common release until bumped again.
> 
> **Overview**
> Reverts the automatic bump to **18.28.0** (PR #1029) by pinning **purchases-hybrid-common** and **purchases-hybrid-common-ui** back to **18.27.0** across the Unity plugin.
> 
> Updates `RevenueCatDependencies.xml`, `RevenueCatUIDependencies.xml`, `RevenueCatUI.androidlib/build.gradle`, and the Subtester Android resolver outputs (`mainTemplate.gradle`, `AndroidResolverDependencies.xml`) so Android, iOS pods, and Swift package versions stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151e7d93b80ee5111bf64569c3a3d5f91b43c201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->