### PR TITLE
feat(ads): ad reward tracking support

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -281,6 +281,9 @@ public class PurchasesAPITests : MonoBehaviour
             Purchases.VerifiedReward reward = result.Reward;
             List<Purchases.VerifiedReward> moreRewards = result.MoreRewards;
         });
+        purchases.PollRewardVerification("client_transaction_id", (result, error) =>
+        {
+        }, new RewardedAdTrackingMetadata(AdTracker.MediatorName.AdMob, AdTracker.Format.Rewarded, "ad_unit", "imp_007", networkName: "network", placement: "main_menu"));
 
         // Win-back offer API tests
         // Purchasing win-back offers with a product

--- a/IntegrationTests/Assets/Tests/EditMode/CallbackResponseTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/CallbackResponseTests.cs
@@ -730,8 +730,9 @@ namespace RevenueCat.Tests
 
             _purchases.PollRewardVerification("txn_abc123", (result, error) => receivedResult = result);
 
-            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.PollRewardVerification), 1);
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.PollRewardVerification), 2);
             Assert.That(invocation.Arguments[0], Is.EqualTo("txn_abc123"));
+            Assert.That(invocation.Arguments[1], Is.Null);
 
             SendNativeResponse("_pollRewardVerification",
                 "{\"failed\":false,\"reward\":{\"type\":\"virtual_currency\",\"code\":\"COIN\",\"amount\":50}," +

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using NUnit.Framework;
+using RevenueCat;
 using RevenueCat.SimpleJSON;
 using UnityEngine;
 
@@ -312,6 +313,42 @@ namespace RevenueCat.Tests
             Assert.That(result.Failed, Is.False);
             Assert.That(result.Reward, Is.InstanceOf<Purchases.VerifiedReward.VirtualCurrency>());
             Assert.That(result.MoreRewards, Is.Empty);
+        }
+
+        [Test]
+        public void RewardedAdTrackingMetadataSerializesAllFields()
+        {
+            var metadata = new RewardedAdTrackingMetadata(
+                AdTracker.MediatorName.AdMob,
+                AdTracker.Format.Rewarded,
+                "ad_unit_1",
+                "impression_1",
+                "network_1",
+                "placement_1");
+
+            var json = JSONNode.Parse(metadata.ToJsonString());
+
+            Assert.That(json["mediatorName"].Value, Is.EqualTo("AdMob"));
+            Assert.That(json["adFormat"].Value, Is.EqualTo("rewarded"));
+            Assert.That(json["adUnitId"].Value, Is.EqualTo("ad_unit_1"));
+            Assert.That(json["impressionId"].Value, Is.EqualTo("impression_1"));
+            Assert.That(json["networkName"].Value, Is.EqualTo("network_1"));
+            Assert.That(json["placement"].Value, Is.EqualTo("placement_1"));
+        }
+
+        [Test]
+        public void RewardedAdTrackingMetadataOmitsOptionalFieldsWhenNull()
+        {
+            var metadata = new RewardedAdTrackingMetadata(
+                AdTracker.MediatorName.AppLovin,
+                AdTracker.Format.Interstitial,
+                "ad_unit_1",
+                "impression_1");
+
+            var json = JSONNode.Parse(metadata.ToJsonString());
+
+            Assert.That(json.HasKey("networkName"), Is.False);
+            Assert.That(json.HasKey("placement"), Is.False);
         }
     }
 }

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesWrapperSpy.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesWrapperSpy.cs
@@ -217,7 +217,8 @@ namespace RevenueCat.Tests
         public void GenerateRewardVerificationToken(string impressionId) =>
             Record(nameof(GenerateRewardVerificationToken), impressionId);
 
-        public void PollRewardVerification(string clientTransactionId) =>
-            Record(nameof(PollRewardVerification), clientTransactionId);
+        public void PollRewardVerification(string clientTransactionId,
+            RevenueCat.RewardedAdTrackingMetadata trackingMetadata = null) =>
+            Record(nameof(PollRewardVerification), clientTransactionId, trackingMetadata);
     }
 }

--- a/RevenueCat/Plugins/Android/PurchasesWrapper.java
+++ b/RevenueCat/Plugins/Android/PurchasesWrapper.java
@@ -852,7 +852,16 @@ public class PurchasesWrapper {
         sendJSONObject(MappersHelpersKt.convertToJson(token), GENERATE_REWARD_VERIFICATION_TOKEN);
     }
 
-    public static void pollRewardVerification(String clientTransactionId) {
+    public static void pollRewardVerification(String clientTransactionId, @Nullable String trackingMetadataJson) {
+        Map<String, ?> trackingMetadata = null;
+        if (trackingMetadataJson != null) {
+            try {
+                JSONObject jsonObject = new JSONObject(trackingMetadataJson);
+                trackingMetadata = MappersHelpersKt.convertToMap(jsonObject);
+            } catch (JSONException e) {
+                logJSONException(e);
+            }
+        }
         CommonKt.pollRewardVerification(clientTransactionId, new OnResult() {
             @Override
             public void onReceived(Map<String, ?> map) {
@@ -863,7 +872,7 @@ public class PurchasesWrapper {
             public void onError(ErrorContainer errorContainer) {
                 sendError(errorContainer, POLL_REWARD_VERIFICATION);
             }
-        });
+        }, trackingMetadata);
     }
 
     private static void logJSONException(JSONException e) {

--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -690,8 +690,18 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
     [self sendJSONObject:token toMethod:GENERATE_REWARD_VERIFICATION_TOKEN];
 }
 
-- (void)pollRewardVerification:(NSString *)clientTransactionId {
+- (void)pollRewardVerification:(NSString *)clientTransactionId trackingMetadataJson:(NSString *)trackingMetadataJson {
+    NSDictionary *trackingMetadata = nil;
+    if (trackingMetadataJson) {
+        NSError *error = nil;
+        trackingMetadata = [NSJSONSerialization JSONObjectWithData:[trackingMetadataJson dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
+        if (error) {
+            NSLog(@"[Purchases] pollRewardVerification: trackingMetadata JSON parse error: %@", error.localizedDescription);
+            trackingMetadata = nil;
+        }
+    }
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:clientTransactionId
+                                                        trackingMetadata:trackingMetadata
                                                              completion:^(NSDictionary *_Nullable result, RCErrorContainer *_Nullable error) {
         if (error == nil && result == nil) {
             NSError *nsError = [[NSError alloc] initWithDomain:RCPurchasesErrorCodeDomain
@@ -1238,8 +1248,9 @@ void _RCGenerateRewardVerificationToken(const char *impressionId) {
     [_RCUnityHelperShared() generateRewardVerificationToken:convertCString(impressionId)];
 }
 
-void _RCPollRewardVerification(const char *clientTransactionId) {
-    [_RCUnityHelperShared() pollRewardVerification:convertCString(clientTransactionId)];
+void _RCPollRewardVerification(const char *clientTransactionId, const char *trackingMetadataJson) {
+    [_RCUnityHelperShared() pollRewardVerification:convertCString(clientTransactionId)
+                              trackingMetadataJson:convertCString(trackingMetadataJson)];
 }
 
 @implementation NSObject (NSNullMapping)

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -742,11 +742,16 @@ public partial class Purchases : MonoBehaviour
     /// <param name="clientTransactionId"> The <see cref="RewardVerificationToken.ClientTransactionId"/>
     /// from <see cref="GenerateRewardVerificationToken"/>.</param>
     /// <param name="callback"> Called with the verification result, or an error if polling failed.</param>
+    /// <param name="trackingMetadata"> Pass to have the SDK automatically track reward-verification
+    /// events for the ad it belongs to; omit to poll without tracking.</param>
     /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
-    public void PollRewardVerification(string clientTransactionId, PollRewardVerificationFunc callback)
+    public void PollRewardVerification(
+        string clientTransactionId,
+        PollRewardVerificationFunc callback,
+        RevenueCat.RewardedAdTrackingMetadata trackingMetadata = null)
     {
         PollRewardVerificationCallback = callback;
-        _wrapper.PollRewardVerification(clientTransactionId);
+        _wrapper.PollRewardVerification(clientTransactionId, trackingMetadata);
     }
 
     /// <summary>

--- a/RevenueCat/Scripts/PurchasesWrapper.cs
+++ b/RevenueCat/Scripts/PurchasesWrapper.cs
@@ -100,5 +100,5 @@ public interface IPurchasesWrapper
     void TrackAdLoaded(AdLoadedData data);
     void TrackAdFailedToLoad(AdFailedToLoadData data);
     void GenerateRewardVerificationToken(string impressionId);
-    void PollRewardVerification(string clientTransactionId);
+    void PollRewardVerification(string clientTransactionId, RevenueCat.RewardedAdTrackingMetadata trackingMetadata = null);
 }

--- a/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperAndroid.cs
@@ -470,8 +470,8 @@ public class PurchasesWrapperAndroid : IPurchasesWrapper
     public void GenerateRewardVerificationToken(string impressionId) =>
         CallPurchases("generateRewardVerificationToken", impressionId);
 
-    public void PollRewardVerification(string clientTransactionId) =>
-        CallPurchases("pollRewardVerification", clientTransactionId);
+    public void PollRewardVerification(string clientTransactionId, RevenueCat.RewardedAdTrackingMetadata trackingMetadata = null) =>
+        CallPurchases("pollRewardVerification", clientTransactionId, trackingMetadata?.ToJsonString());
 
     private const string PurchasesWrapper = "com.revenuecat.purchasesunity.PurchasesWrapper";
 

--- a/RevenueCat/Scripts/PurchasesWrapperNoop.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperNoop.cs
@@ -305,6 +305,6 @@ public partial class Purchases
         public void TrackAdLoaded(AdLoadedData data) { }
         public void TrackAdFailedToLoad(AdFailedToLoadData data) { }
         public void GenerateRewardVerificationToken(string impressionId) { }
-        public void PollRewardVerification(string clientTransactionId) { }
+        public void PollRewardVerification(string clientTransactionId, RevenueCat.RewardedAdTrackingMetadata trackingMetadata = null) { }
     }
 }

--- a/RevenueCat/Scripts/PurchasesWrapperiOS.cs
+++ b/RevenueCat/Scripts/PurchasesWrapperiOS.cs
@@ -591,8 +591,8 @@ public class PurchasesWrapperiOS : IPurchasesWrapper
         _RCGenerateRewardVerificationToken(impressionId);
 
     [DllImport("__Internal")]
-    private static extern void _RCPollRewardVerification(string clientTransactionId);
-    public void PollRewardVerification(string clientTransactionId) =>
-        _RCPollRewardVerification(clientTransactionId);
+    private static extern void _RCPollRewardVerification(string clientTransactionId, string trackingMetadataJson);
+    public void PollRewardVerification(string clientTransactionId, RevenueCat.RewardedAdTrackingMetadata trackingMetadata = null) =>
+        _RCPollRewardVerification(clientTransactionId, trackingMetadata?.ToJsonString());
 }
 #endif

--- a/RevenueCat/Scripts/RewardedAdTrackingMetadata.cs
+++ b/RevenueCat/Scripts/RewardedAdTrackingMetadata.cs
@@ -1,0 +1,51 @@
+using RevenueCat.SimpleJSON;
+
+namespace RevenueCat
+{
+    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
+    public class RewardedAdTrackingMetadata
+    {
+        public AdTracker.MediatorName MediatorName { get; }
+        public AdTracker.Format AdFormat { get; }
+        public string AdUnitId { get; }
+        public string ImpressionId { get; }
+        public string NetworkName { get; }
+        public string Placement { get; }
+
+        public RewardedAdTrackingMetadata(
+            AdTracker.MediatorName mediatorName,
+            AdTracker.Format adFormat,
+            string adUnitId,
+            string impressionId,
+            string networkName = null,
+            string placement = null)
+        {
+            MediatorName = mediatorName;
+            AdFormat = adFormat;
+            AdUnitId = adUnitId;
+            ImpressionId = impressionId;
+            NetworkName = networkName;
+            Placement = placement;
+        }
+
+        public override string ToString() =>
+            $"{nameof(MediatorName)}: {MediatorName.Value}, " +
+            $"{nameof(AdFormat)}: {AdFormat.Value}, " +
+            $"{nameof(AdUnitId)}: {AdUnitId}, " +
+            $"{nameof(ImpressionId)}: {ImpressionId}, " +
+            $"{nameof(NetworkName)}: {NetworkName}, " +
+            $"{nameof(Placement)}: {Placement}";
+
+        public string ToJsonString()
+        {
+            var obj = new JSONObject();
+            obj["mediatorName"] = MediatorName.Value;
+            obj["adFormat"] = AdFormat.Value;
+            obj["adUnitId"] = AdUnitId;
+            obj["impressionId"] = ImpressionId;
+            if (NetworkName != null) obj["networkName"] = NetworkName;
+            if (Placement != null) obj["placement"] = Placement;
+            return obj.ToString();
+        }
+    }
+}

--- a/RevenueCat/Scripts/RewardedAdTrackingMetadata.cs.meta
+++ b/RevenueCat/Scripts/RewardedAdTrackingMetadata.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f7d73acc5794440835155eb1c6e7159


### PR DESCRIPTION
### Description

This change exposes the ad reward tracking functionality, which is just a new parameter for the polling function.

**Do** **not** **merge** until android and ios sdks are released with the feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API on experimental ads/reward verification with native bridge changes; backward compatible via optional parameter but requires matching Android/iOS SDK releases before merge.
> 
> **Overview**
> Adds optional **ad reward tracking** when polling reward verification: `PollRewardVerification` now accepts an optional `RewardedAdTrackingMetadata` argument so the native SDK can auto-track reward-verification events for that ad; omitting it keeps the previous poll-only behavior.
> 
> Introduces **`RewardedAdTrackingMetadata`** (mediator, format, ad unit, impression id, optional network/placement) with JSON serialization that omits null optional fields. The change is threaded through **`IPurchasesWrapper`**, Android/iOS Unity bridges (JSON parse with error logging), and **`Purchases`**.
> 
> Tests cover metadata JSON, wrapper spy arity, API sample usage, and existing poll callback tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b43fd0594c6643d3ae3b7ebe3efed5aa7d8eaf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->