### PR TITLE
feat: add PurchasesConfiguration.Builder.SetProxyURL

### DIFF
--- a/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
+++ b/IntegrationTests/Assets/APITests/PurchasesAPITests.cs
@@ -228,7 +228,9 @@ public class PurchasesAPITests : MonoBehaviour
             .SetDiagnosticsEnabled(true)
             .SetAutomaticDeviceIdentifierCollectionEnabled(false)
             .SetPreferredUILocaleOverride("de_DE")
+            .SetProxyURL("https://proxy.revenuecat.com")
             .Build();
+        string proxyURL = purchasesConfiguration.ProxyURL;
         purchases.Configure(purchasesConfiguration);
         purchases.RecordPurchase("product_id", (transaction, error) => 
         {

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesCallTests.cs
@@ -65,6 +65,42 @@ namespace RevenueCat.Tests
             Assert.That(invocation.Arguments[13], Is.EqualTo("de_DE"));
         }
 
+        /// <remarks>
+        /// The proxy URL has to reach the native SDK before it is configured, so this pins the order
+        /// rather than just the fact that both calls happen.
+        /// </remarks>
+        [Test]
+        public void ConfigureSetsProxyUrlBeforeSettingUp()
+        {
+            var configuration = Purchases.PurchasesConfiguration.Builder
+                .Init("test_api_key")
+                .SetProxyURL("https://proxy.revenuecat.com")
+                .Build();
+
+            _purchases.Configure(configuration);
+
+            Assert.That(_wrapper.Invocations, Has.Count.EqualTo(2));
+            Assert.That(_wrapper.Invocations[0].Method, Is.EqualTo(nameof(IPurchasesWrapper.SetProxyURL)));
+            Assert.That(_wrapper.Invocations[0].Arguments[0], Is.EqualTo("https://proxy.revenuecat.com"));
+            Assert.That(_wrapper.Invocations[1].Method, Is.EqualTo(nameof(IPurchasesWrapper.Setup)));
+        }
+
+        /// <remarks>
+        /// A configuration that carries no proxy URL must not call the wrapper at all, otherwise it would
+        /// clear a proxy URL already set through the inspector field on Purchases.
+        /// </remarks>
+        [Test]
+        public void ConfigureWithoutProxyUrlDoesNotCallSetProxyUrl()
+        {
+            var configuration = Purchases.PurchasesConfiguration.Builder
+                .Init("test_api_key")
+                .Build();
+
+            _purchases.Configure(configuration);
+
+            AssertOnlyInvocation(nameof(IPurchasesWrapper.Setup), 14);
+        }
+
         private PurchasesWrapperSpy.Invocation AssertOnlyInvocation(string method, int argumentCount)
         {
             Assert.That(_wrapper.Invocations, Has.Count.EqualTo(1));

--- a/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/PurchasesConfigurationTests.cs
@@ -36,6 +36,7 @@ namespace RevenueCat.Tests
             Assert.That(configuration.DiagnosticsEnabled, Is.False);
             Assert.That(configuration.AutomaticDeviceIdentifierCollectionEnabled, Is.True);
             Assert.That(configuration.PreferredUILocaleOverride, Is.Null);
+            Assert.That(configuration.ProxyURL, Is.Null);
         }
 
         [Test]
@@ -56,6 +57,7 @@ namespace RevenueCat.Tests
                 .SetDiagnosticsEnabled(true)
                 .SetAutomaticDeviceIdentifierCollectionEnabled(false)
                 .SetPreferredUILocaleOverride("de_DE")
+                .SetProxyURL("https://proxy.revenuecat.com")
                 .Build();
 
             Assert.That(configuration.AppUserId, Is.EqualTo("app_user_id"));
@@ -70,6 +72,7 @@ namespace RevenueCat.Tests
             Assert.That(configuration.DiagnosticsEnabled, Is.True);
             Assert.That(configuration.AutomaticDeviceIdentifierCollectionEnabled, Is.False);
             Assert.That(configuration.PreferredUILocaleOverride, Is.EqualTo("de_DE"));
+            Assert.That(configuration.ProxyURL, Is.EqualTo("https://proxy.revenuecat.com"));
         }
 
         [Test]

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -92,8 +92,9 @@ public partial class Purchases : MonoBehaviour
     [Header("Advanced")]
     [Tooltip("Set this property to your proxy URL before configuring Purchases *only* if you've received " +
              "a proxy key value from your RevenueCat contact.\n" +
-             "NOTE: This value will be ignored if \"Use Runtime Setup\" is true. For Runtime Setup, you can configure " +
-             "it through PurchasesConfiguration instead")]
+             "NOTE: Unlike the other fields here, this one is applied even when \"Use Runtime Setup\" is true. " +
+             "If you configure at runtime you can set it through " +
+             "PurchasesConfiguration.Builder.SetProxyURL instead.")]
     public string proxyURL;
 
     private IPurchasesWrapper _wrapper;
@@ -115,6 +116,11 @@ public partial class Purchases : MonoBehaviour
 #else
         SetWrapper(new PurchasesWrapperNoop());
 #endif
+        // Deliberately applied above the early return, so it takes effect on both the inspector and the
+        // runtime-setup paths. That makes it the one inspector field runtime setup does not ignore: the
+        // others are read by Configure below, which runtime setup skips. Aligning it with them would stop
+        // runtime-setup apps from picking up an inspector-set proxy URL, silently sending their traffic
+        // straight to RevenueCat, so that change is deferred to the next major.
         if (!string.IsNullOrEmpty(proxyURL))
         {
             _wrapper.SetProxyURL(proxyURL);
@@ -194,6 +200,14 @@ public partial class Purchases : MonoBehaviour
     ///
     public void Configure(PurchasesConfiguration purchasesConfiguration)
     {
+        // Only forwarded when set, for two reasons: it mirrors how the inspector field is applied in
+        // Start, and it keeps a configuration that carries no proxy URL from clearing one that was
+        // already set through the inspector.
+        if (!string.IsNullOrEmpty(purchasesConfiguration.ProxyURL))
+        {
+            _wrapper.SetProxyURL(purchasesConfiguration.ProxyURL);
+        }
+
         var dangerousSettings = purchasesConfiguration.DangerousSettings.Serialize().ToString();
         _wrapper.Setup(gameObject.name, purchasesConfiguration.ApiKey, purchasesConfiguration.AppUserId,
             purchasesConfiguration.PurchasesAreCompletedBy, purchasesConfiguration.StoreKitVersion, purchasesConfiguration.UserDefaultsSuiteName,

--- a/RevenueCat/Scripts/PurchasesConfiguration.cs
+++ b/RevenueCat/Scripts/PurchasesConfiguration.cs
@@ -36,11 +36,12 @@ public partial class Purchases
         public readonly bool DiagnosticsEnabled;
         public readonly bool AutomaticDeviceIdentifierCollectionEnabled;
         public readonly string PreferredUILocaleOverride;
+        public readonly string ProxyURL;
 
         private PurchasesConfiguration(string apiKey, string appUserId, PurchasesAreCompletedBy purchasesAreCompletedBy, string userDefaultsSuiteName,
             bool useAmazon, DangerousSettings dangerousSettings, StoreKitVersion storeKitVersion, bool shouldShowInAppMessagesAutomatically,
             EntitlementVerificationMode entitlementVerificationMode, bool pendingTransactionsForPrepaidPlansEnabled, bool diagnosticsEnabled,
-            bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride)
+            bool automaticDeviceIdentifierCollectionEnabled, string preferredUILocaleOverride, string proxyURL)
         {
             ApiKey = apiKey;
             AppUserId = appUserId;
@@ -55,6 +56,7 @@ public partial class Purchases
             DiagnosticsEnabled = diagnosticsEnabled;
             AutomaticDeviceIdentifierCollectionEnabled = automaticDeviceIdentifierCollectionEnabled;
             PreferredUILocaleOverride = preferredUILocaleOverride;
+            ProxyURL = proxyURL;
         }
 
         /// <summary>
@@ -91,6 +93,7 @@ public partial class Purchases
             private bool _diagnosticsEnabled;
             private bool _automaticDeviceIdentifierCollectionEnabled = true;
             private string _preferredUILocaleOverride;
+            private string _proxyURL;
 
             private Builder(string apiKey)
             {
@@ -108,7 +111,7 @@ public partial class Purchases
                 return new PurchasesConfiguration(_apiKey, _appUserId, _purchasesAreCompletedBy, _userDefaultsSuiteName,
                     _useAmazon, _dangerousSettings, _storeKitVersion, _shouldShowInAppMessagesAutomatically,
                     _entitlementVerificationMode, _pendingTransactionsForPrepaidPlansEnabled, _diagnosticsEnabled,
-                    _automaticDeviceIdentifierCollectionEnabled, _preferredUILocaleOverride);
+                    _automaticDeviceIdentifierCollectionEnabled, _preferredUILocaleOverride, _proxyURL);
             }
 
             public Builder SetAppUserId(string appUserId)
@@ -197,6 +200,17 @@ public partial class Purchases
                 return this;
             }
 
+            /// <summary>
+            /// Sets the proxy URL used for all RevenueCat network requests. Only set this if you have
+            /// received a proxy key value from your RevenueCat contact.
+            /// The proxy URL is applied before the SDK is configured.
+            /// </summary>
+            public Builder SetProxyURL(string proxyURL)
+            {
+                _proxyURL = proxyURL;
+                return this;
+            }
+
         }
 
         public override string ToString()
@@ -214,7 +228,8 @@ public partial class Purchases
                 $"{nameof(PendingTransactionsForPrepaidPlansEnabled)}: {PendingTransactionsForPrepaidPlansEnabled}\n" +
                 $"{nameof(DiagnosticsEnabled)}: {DiagnosticsEnabled}\n" +
                 $"{nameof(AutomaticDeviceIdentifierCollectionEnabled)}: {AutomaticDeviceIdentifierCollectionEnabled}\n" +
-                $"{nameof(PreferredUILocaleOverride)}: {PreferredUILocaleOverride}\n";
+                $"{nameof(PreferredUILocaleOverride)}: {PreferredUILocaleOverride}\n" +
+                $"{nameof(ProxyURL)}: {ProxyURL}\n";
         }
     }
 }


### PR DESCRIPTION
The `proxyURL` inspector field's tooltip has always told runtime-setup users to "configure it through PurchasesConfiguration instead", but `PurchasesConfiguration` never had a proxy URL option, so there was nowhere to go. A developer using runtime setup would read that, look for the option, not find it, and reasonably conclude proxy URLs aren't supported for runtime setup.

Adds `PurchasesConfiguration.ProxyURL` and `Builder.SetProxyURL(string)`.

`Configure` forwards it to the wrapper before calling `Setup`, since the native SDKs need the proxy in place before they're configured. It's only forwarded when set. That guard matters for more than tidiness: an unconditional call would pass `null` for every configuration without a proxy URL and clear one that had already been set through the inspector field in `Start`.

Also fixes the tooltip, which was wrong twice. It claimed the value "will be ignored if Use Runtime Setup is true", but `Start` applies it at `Purchases.cs:119-121`, before the `if (useRuntimeSetup) return;` on line 124. It takes effect on both paths, and now the pointer to the builder is accurate too.

That note is shared boilerplate across 8 inspector fields, and it is correct for the other 7: the API keys, `useAmazon`, `autoSyncPurchases`, `appUserID`, `productIdentifiers`, `userDefaultsSuiteName` and `purchasesAreCompletedBy` are all read inside `Configure` or below the early return, so runtime setup really does skip them. `proxyURL` is the only field applied above it, and it looks like the note was just inherited from its neighbours. Git history backs that up: the `proxyURL` block was added in #25 before runtime setup existed, has one commit in its whole history and has never moved, while `useRuntimeSetup` arrived later in #118 and the note later still in #125. So the note was already false when it was written, rather than being made stale by a refactor. That is also why the new wording leads with "unlike the other fields here".

## Known inconsistency, deferred to the next major

This PR does not make `proxyURL` behave like its neighbours, and that is on purpose.

`proxyURL` stays the one inspector field runtime setup does not ignore. The consistent version would move it below the `if (useRuntimeSetup) return;`, so that runtime-setup apps had to use `Builder.SetProxyURL` and the original boilerplate note became true. I did not do that here because it silently breaks a working setup: anyone using runtime setup together with the inspector field has a working proxy today, and after such a change their traffic would go straight to RevenueCat's default endpoints with no error and no log line. Proxy URLs are handed out to customers who proxy for egress control, compliance or regional routing, so silently bypassing it is worse than failing loudly.

There is also a wrinkle that makes the "consistent" version less clean than it sounds. The proxy has to reach the native SDK before configure, and for inspector-configured apps `Start` is the only place that can happen, so the current placement is the one spot that serves both paths. Moving it down would make the inspector field dead for runtime setup unless `Configure` fell back to reading it, which would mix inspector state into a runtime configuration object.

So the alignment is deferred to the next major, alongside #1018, which is the same family of inspector-path versus runtime-path divergence. There is a comment at the application site in `Start` recording this, so it does not read as an oversight.

## Parity

No native or purchases-hybrid-common change is needed. `CommonFunctionality.proxyURLString` and `setProxyURLString` (`common.kt:876`) already exist on both platforms, and all three Unity wrappers already implement `SetProxyURL`. This also matches Android, where `proxyURL` lives on the configuration builder rather than being a separate static.

## Behavior change

None for existing apps. This is additive: the new field defaults to null, and a configuration that doesn't set it behaves exactly as before, including leaving an inspector-set proxy URL alone.

## Tests

- `PurchasesAPITests` exercises `SetProxyURL` and reads `ProxyURL` back, for compile-time API stability.
- `BuildUsesBuilderDefaults` asserts the default is null; `BuildUsesConfiguredValues` asserts it round-trips.
- `ConfigureSetsProxyUrlBeforeSettingUp` pins the ordering, not just that both calls happen.
- `ConfigureWithoutProxyUrlDoesNotCallSetProxyUrl` pins the guard.

The last two were mutation-tested against the real runner. Each mutation failed exactly the intended test and nothing else:

| Mutation | Result |
|---|---|
| Delete the `SetProxyURL` call | `ConfigureSetsProxyUrlBeforeSettingUp` fails, invocation count 2 to 1 |
| Remove the guard | `ConfigureWithoutProxyUrlDoesNotCallSetProxyUrl` fails, count 1 to 2 |
| Call it after `Setup` | `ConfigureSetsProxyUrlBeforeSettingUp` fails, first invocation was `Setup` |

Removing the guard also breaks the pre-existing `ConfigureForwardsEveryConfigurationValue`, which is the other reason it's there.

## Verification

- [x] `test-edit-mode` locally on Unity 6000.2.6f2: 23/23 passed, 0 failed, 0 skipped, and 23/23 again after restoring from the mutation runs.
- [x] `scripts/check-meta-files.sh`
- [ ] CI

