### PR TITLE
Stop sending the purchase response twice on iOS errors

### DIFF
--- a/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
+++ b/RevenueCat/Plugins/iOS/PurchasesUnityHelper.m
@@ -150,10 +150,9 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response = [NSMutableDictionary new];
             response[@"error"] = error.info;
             response[@"userCancelled"] = error.info[@"userCancelled"];
-            [self sendJSONObject:response toMethod:MAKE_PURCHASE];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
-            response[@"userCancelled"] = false;
+            response[@"userCancelled"] = @NO;
         }
         [self sendJSONObject:response toMethod:MAKE_PURCHASE];
     }];
@@ -171,7 +170,6 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response = [NSMutableDictionary new];
             response[@"error"] = error.info;
             response[@"userCancelled"] = error.info[@"userCancelled"];
-            [self sendJSONObject:response toMethod:MAKE_PURCHASE];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
             response[@"userCancelled"] = @NO;
@@ -548,7 +546,7 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response[@"userCancelled"] = error.info[@"userCancelled"];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
-            response[@"userCancelled"] = false;
+            response[@"userCancelled"] = @NO;
         }
         [self sendJSONObject:response toMethod:PURCHASE_PRODUCT_WITH_WIN_BACK_OFFER];
     }];
@@ -583,7 +581,7 @@ signedDiscountTimestamp:(NSString *)signedDiscountTimestamp {
             response[@"userCancelled"] = error.info[@"userCancelled"];
         } else {
             response = [NSMutableDictionary dictionaryWithDictionary:responseDictionary];
-            response[@"userCancelled"] = false;
+            response[@"userCancelled"] = @NO;
         }
         [self sendJSONObject:response toMethod:PURCHASE_PACKAGE_WITH_WIN_BACK_OFFER];
     }];


### PR DESCRIPTION
`purchaseProduct` and `purchasePackage` in `PurchasesUnityHelper.m` called `sendJSONObject` inside the error branch and again after the `if/else`, so a failed purchase delivered the same payload to Unity twice. The win-back variants already sent it once correctly.

Unity absorbs the duplicate today because `Purchases.cs` nulls `MakePurchaseCallback` before invoking it, so the second delivery hits the null guard. The exposure is a caller that starts a new purchase from inside the error callback: the queued duplicate can then land on the retry's callback carrying the stale error.

Also replaces the C literal `false` with `@NO` in the four success paths. Assigning `false` to an `NSMutableDictionary` subscript passes `nil`, which removes the key rather than storing `@NO`, so `userCancelled` was absent from successful `purchaseProduct` and win-back payloads while `purchasePackage` included it. Consumers see no behaviour change, since `PurchaseResult` defaults to false on a missing key, but the payload is now consistent across all four paths and with Android.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core purchase-to-Unity bridging on iOS; the duplicate-callback fix changes timing for error handling and could affect apps that retry purchases from within the error callback, but the change reduces incorrect double delivery rather than altering success paths.
> 
> **Overview**
> Fixes **duplicate Unity callbacks** on failed iOS purchases for `purchaseProduct` and `purchasePackage` in `PurchasesUnityHelper.m`. Those paths previously called `sendJSONObject` inside the error branch and again after the `if/else`, so a failed purchase could deliver the same payload twice. The win-back purchase handlers already sent once; product/package now match that pattern with a **single** `sendJSONObject` after building the response.
> 
> On successful purchases, **`userCancelled` is now set with `@NO`** instead of the C literal `false` in all four purchase completion paths (product, package, and both win-back variants). Using `false` on an `NSMutableDictionary` subscript passes `nil` and drops the key; `@NO` stores an explicit false. Payload shape is aligned across paths and with Android; `PurchaseResult` still defaults missing `userCancelled` to false, so typical app behavior should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ba8c2049ecd97e8a9620dc650cac1688080896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->