### PR TITLE
chore(ads): add tests to reward verification primitives

### DIFF
--- a/IntegrationTests/Assets/Tests/EditMode/CallbackResponseTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/CallbackResponseTests.cs
@@ -686,6 +686,103 @@ namespace RevenueCat.Tests
             Assert.That(receivedError.ReadableErrorCode, Is.EqualTo("StoreProblemError"));
         }
 
+        [Test]
+        public void GenerateRewardVerificationTokenDeliversToken()
+        {
+            Purchases.RewardVerificationToken receivedToken = null;
+
+            _purchases.GenerateRewardVerificationToken("impression_1", (token, error) => receivedToken = token);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.GenerateRewardVerificationToken), 1);
+            Assert.That(invocation.Arguments[0], Is.EqualTo("impression_1"));
+
+            SendNativeResponse("_generateRewardVerificationToken",
+                "{\"customData\":\"txn_abc123\",\"clientTransactionId\":\"txn_abc123\",\"appUserID\":\"user_1\"}");
+
+            Assert.That(receivedToken, Is.Not.Null);
+            Assert.That(receivedToken.ClientTransactionId, Is.EqualTo("txn_abc123"));
+        }
+
+        [Test]
+        public void GenerateRewardVerificationTokenDeliversNativeError()
+        {
+            Purchases.RewardVerificationToken receivedToken = null;
+            Purchases.Error receivedError = null;
+
+            _purchases.GenerateRewardVerificationToken("impression_1", (token, error) =>
+            {
+                receivedToken = token;
+                receivedError = error;
+            });
+
+            SendNativeResponse("_generateRewardVerificationToken", ErrorJson(10, "There was a network error.",
+                "NETWORK_ERROR"));
+
+            Assert.That(receivedToken, Is.Null);
+            Assert.That(receivedError, Is.Not.Null);
+            Assert.That(receivedError.Code, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void PollRewardVerificationDeliversRewardResult()
+        {
+            Purchases.RewardVerificationResult receivedResult = null;
+
+            _purchases.PollRewardVerification("txn_abc123", (result, error) => receivedResult = result);
+
+            var invocation = AssertLastInvocation(nameof(IPurchasesWrapper.PollRewardVerification), 1);
+            Assert.That(invocation.Arguments[0], Is.EqualTo("txn_abc123"));
+
+            SendNativeResponse("_pollRewardVerification",
+                "{\"failed\":false,\"reward\":{\"type\":\"virtual_currency\",\"code\":\"COIN\",\"amount\":50}," +
+                "\"moreRewards\":[]}");
+
+            Assert.That(receivedResult, Is.Not.Null);
+            Assert.That(receivedResult.Failed, Is.False);
+            Assert.That(receivedResult.Reward, Is.InstanceOf<Purchases.VerifiedReward.VirtualCurrency>());
+        }
+
+        [Test]
+        public void PollRewardVerificationDeliversFailedResultWithoutError()
+        {
+            // A rejected/timed-out verification is reported as Failed = true, not as an error.
+            Purchases.RewardVerificationResult receivedResult = null;
+            Purchases.Error receivedError = null;
+
+            _purchases.PollRewardVerification("txn_abc123", (result, error) =>
+            {
+                receivedResult = result;
+                receivedError = error;
+            });
+
+            SendNativeResponse("_pollRewardVerification", "{\"failed\":true,\"reward\":null,\"moreRewards\":null}");
+
+            Assert.That(receivedResult, Is.Not.Null);
+            Assert.That(receivedResult.Failed, Is.True);
+            Assert.That(receivedResult.Reward, Is.Null);
+            Assert.That(receivedError, Is.Null);
+        }
+
+        [Test]
+        public void PollRewardVerificationDeliversNativeError()
+        {
+            Purchases.RewardVerificationResult receivedResult = null;
+            Purchases.Error receivedError = null;
+
+            _purchases.PollRewardVerification("txn_abc123", (result, error) =>
+            {
+                receivedResult = result;
+                receivedError = error;
+            });
+
+            SendNativeResponse("_pollRewardVerification", ErrorJson(10, "There was a network error.",
+                "NETWORK_ERROR"));
+
+            Assert.That(receivedResult, Is.Null);
+            Assert.That(receivedError, Is.Not.Null);
+            Assert.That(receivedError.Code, Is.EqualTo(10));
+        }
+
         private PurchasesWrapperSpy.Invocation AssertLastInvocation(string method, int argumentCount)
         {
             Assert.That(_wrapper.Invocations, Has.Count.EqualTo(1));

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-failed.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-failed.json
@@ -1,0 +1,1 @@
+{"failed":true,"reward":null,"moreRewards":null}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-failed.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-failed.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f92f2cd1251049afa184219047fd0be0
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-null-more-rewards.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-null-more-rewards.json
@@ -1,0 +1,1 @@
+{"failed":false,"reward":{"type":"virtual_currency","code":"COIN","amount":50},"moreRewards":null}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-null-more-rewards.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-null-more-rewards.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d46e87ae07248af98fd8412014df991
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-success.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-success.json
@@ -1,0 +1,2 @@
+{"failed":false,"reward":{"type":"virtual_currency","code":"COIN","amount":50},
+"moreRewards":[{"type":"entitlement","identifier":"premium","expiresAt":"2023-11-14T22:13:20.000Z","expiresAtMillis":1700000000000}]}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-success.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-result-success.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12f056332e86430b81c9b8af3e6addc7
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-token.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-token.json
@@ -1,0 +1,1 @@
+{"customData":"txn_abc123","clientTransactionId":"txn_abc123","appUserID":"user_1"}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-token.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/reward-verification-token.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 27c1a5554a654e9aa9d9faad9a77360f
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-entitlement.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-entitlement.json
@@ -1,0 +1,1 @@
+{"type":"entitlement","identifier":"premium","expiresAt":"2023-11-14T22:13:20.000Z","expiresAtMillis":1700000000000}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-entitlement.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-entitlement.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 044df7f9c03f48ba8094c2c5201d1d33
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-no-reward.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-no-reward.json
@@ -1,0 +1,1 @@
+{"type":"no_reward"}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-no-reward.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-no-reward.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac5c1a7b0f944c3689a1b252d967e647
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-unsupported.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-unsupported.json
@@ -1,0 +1,1 @@
+{"type":"new_reward_type_not_yet_modeled"}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-unsupported.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-unsupported.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 84fd8620a4ef40c8bc2e09246447ec94
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-virtual-currency.json
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-virtual-currency.json
@@ -1,0 +1,1 @@
+{"type":"virtual_currency","code":"COIN","amount":50}

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-virtual-currency.json.meta
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelFixtures/verified-reward-virtual-currency.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2c95c03b73044d20bd2a67efdf14fcd2
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
+++ b/IntegrationTests/Assets/Tests/EditMode/JsonModelTests.cs
@@ -217,5 +217,101 @@ namespace RevenueCat.Tests
 
             Assert.Throws<ArgumentException>(() => Purchases.WebPurchaseRedemptionResult.FromJson(response));
         }
+
+        [Test]
+        public void RewardVerificationTokenParsesFields()
+        {
+            var response = LoadFixture("reward-verification-token.json");
+
+            var token = new Purchases.RewardVerificationToken(response);
+
+            Assert.That(token.CustomData, Is.EqualTo("txn_abc123"));
+            Assert.That(token.ClientTransactionId, Is.EqualTo("txn_abc123"));
+            Assert.That(token.AppUserID, Is.EqualTo("user_1"));
+        }
+
+        [Test]
+        public void VerifiedRewardParsesVirtualCurrencyVariant()
+        {
+            var response = LoadFixture("verified-reward-virtual-currency.json");
+
+            var reward = (Purchases.VerifiedReward.VirtualCurrency)Purchases.VerifiedReward.FromJson(response);
+
+            Assert.That(reward.Code, Is.EqualTo("COIN"));
+            Assert.That(reward.Amount, Is.EqualTo(50));
+        }
+
+        [Test]
+        public void VerifiedRewardParsesEntitlementVariant()
+        {
+            var response = LoadFixture("verified-reward-entitlement.json");
+
+            var reward = (Purchases.VerifiedReward.Entitlement)Purchases.VerifiedReward.FromJson(response);
+
+            Assert.That(reward.Identifier, Is.EqualTo("premium"));
+            Assert.That(reward.ExpiresAt, Is.EqualTo("2023-11-14T22:13:20.000Z"));
+            Assert.That(reward.ExpiresAtMillis, Is.EqualTo(1700000000000));
+        }
+
+        [Test]
+        public void VerifiedRewardParsesNoRewardVariant()
+        {
+            var response = LoadFixture("verified-reward-no-reward.json");
+
+            var reward = Purchases.VerifiedReward.FromJson(response);
+
+            Assert.That(reward, Is.SameAs(Purchases.VerifiedReward.NoReward.Instance));
+        }
+
+        [Test]
+        public void VerifiedRewardFallsBackToUnsupportedForUnrecognizedType()
+        {
+            // Deliberately synthetic, like the UNRECOGNIZED category tests above: stands in for a
+            // reward type added natively before Unity knows about it.
+            var response = LoadFixture("verified-reward-unsupported.json");
+
+            var reward = Purchases.VerifiedReward.FromJson(response);
+
+            Assert.That(reward, Is.SameAs(Purchases.VerifiedReward.Unsupported.Instance));
+        }
+
+        [Test]
+        public void RewardVerificationResultParsesRewardAndMoreRewards()
+        {
+            var response = LoadFixture("reward-verification-result-success.json");
+
+            var result = new Purchases.RewardVerificationResult(response);
+
+            Assert.That(result.Failed, Is.False);
+            Assert.That(result.Reward, Is.InstanceOf<Purchases.VerifiedReward.VirtualCurrency>());
+            Assert.That(result.MoreRewards, Has.Count.EqualTo(1));
+            Assert.That(result.MoreRewards[0], Is.InstanceOf<Purchases.VerifiedReward.Entitlement>());
+        }
+
+        [Test]
+        public void RewardVerificationResultLeavesRewardNullWhenFailed()
+        {
+            var response = LoadFixture("reward-verification-result-failed.json");
+
+            var result = new Purchases.RewardVerificationResult(response);
+
+            Assert.That(result.Failed, Is.True);
+            Assert.That(result.Reward, Is.Null);
+            Assert.That(result.MoreRewards, Is.Empty);
+        }
+
+        [Test]
+        public void RewardVerificationResultTreatsExplicitNullMoreRewardsAsEmpty()
+        {
+            // moreRewards can arrive as an explicit JSON null rather than an empty array or a
+            // missing key; this must not throw.
+            var response = LoadFixture("reward-verification-result-null-more-rewards.json");
+
+            var result = new Purchases.RewardVerificationResult(response);
+
+            Assert.That(result.Failed, Is.False);
+            Assert.That(result.Reward, Is.InstanceOf<Purchases.VerifiedReward.VirtualCurrency>());
+            Assert.That(result.MoreRewards, Is.Empty);
+        }
     }
 }


### PR DESCRIPTION
### Description



Adds test coverage to reward verification primitive bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (fixtures and EditMode tests) with no modifications to runtime SDK behavior.
> 
> **Overview**
> Adds **EditMode test coverage** for the ads reward-verification Unity bridge and JSON models—no production code changes.
> 
> **Callback wiring** (`CallbackResponseTests`): exercises `GenerateRewardVerificationToken` and `PollRewardVerification` through the spy wrapper and simulated native `UnitySendMessage` responses (`_generateRewardVerificationToken`, `_pollRewardVerification`). Covers successful token delivery, network-style native errors, successful poll with a virtual-currency reward, **failed verification as `failed: true` without an error object**, and poll native errors.
> 
> **JSON parsing** (`JsonModelTests` + fixtures): pins `RewardVerificationToken` fields; `VerifiedReward` variants (virtual currency, entitlement, no reward, unsupported type fallback); and `RewardVerificationResult` success, failed, and explicit `moreRewards: null` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1adacc264455c227e8c00871ee85959e0c569954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->