### PR TITLE
Update sdks-common-config orb to v4.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ aliases:
         only: main
 
 orbs:
-  revenuecat: revenuecat/sdks-common-config@4.5.1
+  revenuecat: revenuecat/sdks-common-config@4.6.1
   unity: game-ci/unity@1.7.1
   android: circleci/android@3.0.2
 


### PR DESCRIPTION
### Motivation

Keep CI on the latest shared orb release: [v4.6.1](https://github.com/RevenueCat/sdks-circleci-orb/releases/tag/v4.6.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single orb version pin change in CircleCI config; no application or security logic is modified. Risk is limited to CI behavior from the new orb release.
> 
> **Overview**
> Bumps the CircleCI `revenuecat/sdks-common-config` orb from `4.5.1` to `4.6.1` so CI uses the latest shared SDK config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d337bad73caa18945acc65aca5e8f62eb296bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->