### PR TITLE
chore(ads): remove experimental remarks from ads apis

### DIFF
--- a/RevenueCat/Scripts/AdDisplayedData.cs
+++ b/RevenueCat/Scripts/AdDisplayedData.cs
@@ -2,7 +2,6 @@ using RevenueCat.SimpleJSON;
 
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class AdDisplayedData
     {
         public AdTracker.MediatorName MediatorName { get; }

--- a/RevenueCat/Scripts/AdFailedToLoadData.cs
+++ b/RevenueCat/Scripts/AdFailedToLoadData.cs
@@ -2,7 +2,6 @@ using RevenueCat.SimpleJSON;
 
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class AdFailedToLoadData
     {
         public AdTracker.MediatorName MediatorName { get; }

--- a/RevenueCat/Scripts/AdLoadedData.cs
+++ b/RevenueCat/Scripts/AdLoadedData.cs
@@ -2,7 +2,6 @@ using RevenueCat.SimpleJSON;
 
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class AdLoadedData
     {
         public AdTracker.MediatorName MediatorName { get; }

--- a/RevenueCat/Scripts/AdOpenedData.cs
+++ b/RevenueCat/Scripts/AdOpenedData.cs
@@ -2,7 +2,6 @@ using RevenueCat.SimpleJSON;
 
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class AdOpenedData
     {
         public AdTracker.MediatorName MediatorName { get; }

--- a/RevenueCat/Scripts/AdRevenueData.cs
+++ b/RevenueCat/Scripts/AdRevenueData.cs
@@ -2,7 +2,6 @@ using RevenueCat.SimpleJSON;
 
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class AdRevenueData
     {
         public AdTracker.MediatorName MediatorName { get; }

--- a/RevenueCat/Scripts/AdTracker.cs
+++ b/RevenueCat/Scripts/AdTracker.cs
@@ -1,9 +1,7 @@
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class AdTracker
     {
-        /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
         public class MediatorName
         {
             public string Value { get; }
@@ -22,7 +20,6 @@ namespace RevenueCat
             public static bool operator !=(MediatorName a, MediatorName b) => !Equals(a, b);
         }
 
-        /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
         public class Format
         {
             public string Value { get; }
@@ -46,7 +43,6 @@ namespace RevenueCat
             public static bool operator !=(Format a, Format b) => !Equals(a, b);
         }
 
-        /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
         public class Precision
         {
             public string Value { get; }

--- a/RevenueCat/Scripts/Purchases.cs
+++ b/RevenueCat/Scripts/Purchases.cs
@@ -97,7 +97,6 @@ public partial class Purchases : MonoBehaviour
     public string proxyURL;
 
     private IPurchasesWrapper _wrapper;
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public RevenueCat.AdTracker AdTracker { get; private set; }
 
     internal void SetWrapper(IPurchasesWrapper wrapper)
@@ -701,7 +700,6 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     /// <param name="token"> The generated token if the request was successful, null otherwise.</param>
     /// <param name="error"> The error if the request was unsuccessful, null otherwise.</param>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public delegate void GenerateRewardVerificationTokenFunc(RewardVerificationToken token, Error error);
 
     private GenerateRewardVerificationTokenFunc GenerateRewardVerificationTokenCallback { get; set; }
@@ -711,7 +709,6 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     /// <param name="result"> The verification result if the request was successful, null otherwise.</param>
     /// <param name="error"> The error if the request was unsuccessful, null otherwise.</param>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public delegate void PollRewardVerificationFunc(RewardVerificationResult result, Error error);
 
     private PollRewardVerificationFunc PollRewardVerificationCallback { get; set; }
@@ -725,7 +722,6 @@ public partial class Purchases : MonoBehaviour
     /// </summary>
     /// <param name="impressionId"> The impression identifier of the rewarded ad.</param>
     /// <param name="callback"> Called with the generated token, or an error if generation failed.</param>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public void GenerateRewardVerificationToken(string impressionId, GenerateRewardVerificationTokenFunc callback)
     {
         GenerateRewardVerificationTokenCallback = callback;
@@ -744,7 +740,6 @@ public partial class Purchases : MonoBehaviour
     /// <param name="callback"> Called with the verification result, or an error if polling failed.</param>
     /// <param name="trackingMetadata"> Pass to have the SDK automatically track reward-verification
     /// events for the ad it belongs to; omit to poll without tracking.</param>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public void PollRewardVerification(
         string clientTransactionId,
         PollRewardVerificationFunc callback,

--- a/RevenueCat/Scripts/RewardVerificationResult.cs
+++ b/RevenueCat/Scripts/RewardVerificationResult.cs
@@ -7,7 +7,6 @@ public partial class Purchases
     /// <summary>
     /// Result of polling for reward verification. A single ad can grant multiple rewards.
     /// </summary>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class RewardVerificationResult
     {
         /// <summary>

--- a/RevenueCat/Scripts/RewardVerificationToken.cs
+++ b/RevenueCat/Scripts/RewardVerificationToken.cs
@@ -7,7 +7,6 @@ public partial class Purchases
     /// to the ad network as server-side verification custom data, then to
     /// <see cref="Purchases.PollRewardVerification"/> to await the reward.
     /// </summary>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class RewardVerificationToken
     {
         /// <summary>

--- a/RevenueCat/Scripts/RewardedAdTrackingMetadata.cs
+++ b/RevenueCat/Scripts/RewardedAdTrackingMetadata.cs
@@ -2,7 +2,6 @@ using RevenueCat.SimpleJSON;
 
 namespace RevenueCat
 {
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public class RewardedAdTrackingMetadata
     {
         public AdTracker.MediatorName MediatorName { get; }

--- a/RevenueCat/Scripts/VerifiedReward.cs
+++ b/RevenueCat/Scripts/VerifiedReward.cs
@@ -6,7 +6,6 @@ public partial class Purchases
     /// A reward granted after a verified rewarded ad. Switch on the concrete subtype to read the
     /// fields relevant to that reward.
     /// </summary>
-    /// <remarks>Experimental: this API is unstable and may change in a future release.</remarks>
     public abstract class VerifiedReward
     {
         private VerifiedReward() { }


### PR DESCRIPTION
Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only removal of experimental warnings; no runtime or API contract changes.
> 
> **Overview**
> Removes the **Experimental: this API is unstable and may change in a future release** XML doc remarks from the Unity SDK’s ads surface area. No method signatures, behavior, or implementation changes—only public API documentation is updated.
> 
> Coverage includes **ad tracking** (`AdTracker`, event payload types like `AdDisplayedData` / `AdRevenueData`, and `Purchases.AdTracker`), plus **rewarded-ad server verification** (`GenerateRewardVerificationToken`, `PollRewardVerification`, and related types such as `RewardVerificationToken`, `RewardVerificationResult`, `VerifiedReward`, and `RewardedAdTrackingMetadata`).
> 
> This effectively marks those APIs as stable in generated docs and IDE tooltips instead of warning integrators that they may break without notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61a6944cc9c1bc1deb9c49676a538042e9a9580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->