### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with empty token permissions and no PR code execution; requires a configured Slack webhook secret.
> 
> **Overview**
> Adds a new GitHub Actions workflow that notifies an internal Slack channel when a pull request is **opened** by a contributor outside the RevenueCat organization.
> 
> The workflow runs on `pull_request_target` (so fork PRs can use repo secrets) and delegates to the shared `revenuecat/sdk-github-workflows` reusable workflow at a pinned commit (`v7`), passing `EXTERNAL_PR_SLACK_WEBHOOK_URL`. The job sets **`permissions: {}`** so the default `GITHUB_TOKEN` has no scopes, and it does not check out or execute PR code from this repo file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20543c865c2fe76ed83b8e730510f3d4ed43d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->