### PR TITLE
ci: bump external PR notifications workflow to v8

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -8,6 +8,6 @@ permissions: {}
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@b679120ce2931ac2e5c02166f84ad1f9b263fb96 # v8
     secrets:
       EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Bumps the shared workflow to `v8`, which gates on `head.repo.fork` instead of `author_association` so PRs from org members with private membership stop being posted as external. See RevenueCat/sdk-github-workflows#11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow version bump; behavior change is limited to Slack notification eligibility for opened PRs.
> 
> **Overview**
> Updates the **External PR Notifications** reusable workflow pin from **v7** to **v8** (`sdk-github-workflows`).
> 
> That upstream release changes how “external” PRs are detected: notifications now key off **`head.repo.fork`** instead of **`author_association`**, so PRs opened by org members with private membership are no longer mislabeled and posted to Slack as external.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec16a2408b7ce0a69ca5d53b57ad3c1c3c6aacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->